### PR TITLE
Add onlyInitializing modifier for _mint function to prevent subsequen…

### DIFF
--- a/src/Token.sol
+++ b/src/Token.sol
@@ -70,6 +70,28 @@ contract AjnaToken is Initializable, ERC20Upgradeable, ERC20BurnableUpgradeable,
     {
         super._burn(account_, amount_);
     }
+
+    /**************************/
+    /*** External Functions ***/
+    /**************************/
+
+    /**
+     *  @notice Called by an Token owner to enable their tokens to be transferred by a spender address without making a seperate permit call
+     *  @param  from_     The address of the current owner of the tokens
+     *  @param  to_       The address of the new owner of the tokens
+     *  @param  spender_  The address of the third party who will execute the transaction involving an owners tokens
+     *  @param  value_    The amount of tokens to transfer
+     *  @param  deadline_ The unix timestamp by which the permit must be called
+     *  @param  v_        Component of secp256k1 signature
+     *  @param  r_        Component of secp256k1 signature
+     *  @param  s_        Component of secp256k1 signature
+     */
+    function safeTransferFromWithPermit(
+        address from_, address to_, address spender_, uint256 value_, uint256 deadline_, uint8 v_, bytes32 r_, bytes32 s_
+    ) external {
+        permit(from_, spender_, value_, deadline_, v_, r_, s_);
+        transferFrom(from_, to_, value_);
+    }
 }
 
 contract UUPSProxy is ERC1967Proxy {

--- a/src/Token.sol
+++ b/src/Token.sol
@@ -58,6 +58,7 @@ contract AjnaToken is Initializable, ERC20Upgradeable, ERC20BurnableUpgradeable,
 
     function _mint(address to_, uint256 amount_)
         internal
+        onlyInitializing
         override(ERC20Upgradeable, ERC20VotesUpgradeable)
     {
         super._mint(to_, amount_);

--- a/test/utils/SigUtils.sol
+++ b/test/utils/SigUtils.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.14;
+
+contract SigUtils {
+    bytes32 internal DOMAIN_SEPARATOR;
+
+    constructor(bytes32 _DOMAIN_SEPARATOR) {
+        DOMAIN_SEPARATOR = _DOMAIN_SEPARATOR;
+    }
+
+    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public constant PERMIT_TYPEHASH =
+        0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+
+    struct Permit {
+        address owner;
+        address spender;
+        uint256 value;
+        uint256 nonce;
+        uint256 deadline;
+    }
+
+    // computes the hash of a permit
+    function getStructHash(Permit memory _permit)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encode(
+                    PERMIT_TYPEHASH,
+                    _permit.owner,
+                    _permit.spender,
+                    _permit.value,
+                    _permit.nonce,
+                    _permit.deadline
+                )
+            );
+    }
+
+    // computes the hash of the fully encoded EIP-712 message for the domain, which can be used to recover the signer
+    function getTypedDataHash(Permit memory _permit)
+        public
+        view
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    DOMAIN_SEPARATOR,
+                    getStructHash(_permit)
+                )
+            );
+    }
+}


### PR DESCRIPTION
…t mintings

Add SigUtils contract for create, hash, and sign the approvals off-chain
Implement additional tests:
- improve testRenounceOwnership test, check that upgrade and transferOwnership is no longer possible after renounceOwnership
- testCanMint by using a token contract which publicly expose mint function
- testTransferWithApprove and withPermit using fuzzed amounts (between 0 and max supply)
- vote related tests

TBD:
- is OK for testRemoveUpgradeability to be tested by renouncing to ownership?
- does testVote need to simulate an actual voting?