### PR TITLE
Ci slither

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,0 +1,14 @@
+name: Slither Analysis
+on: [push]
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: crytic/slither-action@v0.1.1
+        with:
+          target: 'src/BaseToken.sol'
+          solc-version: 0.8.14
+          slither-config: slither.config.json

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -7,8 +7,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: crytic/slither-action@v0.1.1
-        with:
-          target: 'src/BaseToken.sol'
-          solc-version: 0.8.14
-          slither-config: slither.config.json
+
+      - name: Install and set solc version
+        run: |
+          pip install solc-select && solc-select install 0.8.14 && solc-select use 0.8.14
+        id: solc
+
+      - name: Install Slither
+        run: |
+          pip install slither-analyzer
+        id: slither
+
+      - name: Analyze AjnaToken
+        run: |
+          slither src/BaseToken.sol
+        id: analyzer

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,6 @@
+{
+    "filter_paths": "lib",
+    "solc_remaps": [
+      "@oz=lib/openzeppelin-contracts/contracts/"
+    ]
+  }

--- a/slither.config.json
+++ b/slither.config.json
@@ -3,5 +3,5 @@
     "solc_remaps": [
       "@oz=lib/openzeppelin-contracts/contracts/"
     ],
-    "exclude_informational": true
+    "detectors_to_exclude": "solc-version"
   }

--- a/slither.config.json
+++ b/slither.config.json
@@ -2,5 +2,6 @@
     "filter_paths": "lib",
     "solc_remaps": [
       "@oz=lib/openzeppelin-contracts/contracts/"
-    ]
+    ],
+    "exclude_informational": true
   }


### PR DESCRIPTION
- added GH actions slither analyzer and config file
- excluded `solc-version` detector. If using it it complains about solc `0.8.14` which is too recent to be trusted
```
Pragma version0.8.14 (src/BaseToken.sol#2) necessitates a version too recent to be trusted. Consider deploying with 0.6.12/0.7.6/0.8.7
solc-0.8.14 is not recommended for deployment
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity
```
Another approach would be to not exclude informational either and to always pass analyzer target / check reports after