### PR TITLE
Check duplicates s119

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 ## Ethereum node endpoint ##
-ETH_RPC_URL =
+ETH_RPC_URL=

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -182,6 +182,26 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         }
     }
 
+    /**
+     * @notice Check an array of proposalIds for duplicate IDs.
+     * @param  proposalIdSubset_ Array of proposal Ids to check.
+     * @return Boolean indicating the presence of a duplicate. True if it has a duplicate; false if not.
+     */
+    function _hasDuplicates(uint256[] calldata proposalIds_) internal pure returns (bool) {
+        for (uint i = 0; i < proposalIds_.length; ) {
+            for (uint j = i + 1; j < proposalIds_.length; ) {
+                if (proposalIds_[i] == proposalIds_[j]) return true;
+                unchecked {
+                    ++j;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        return false;
+    }
+
     /// @inheritdoc IStandardFunding
     function checkSlate(uint256[] calldata proposalIds_, uint256 distributionId_) external returns (bool) {
         QuarterlyDistribution storage currentDistribution = distributions[distributionId_];
@@ -190,6 +210,9 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         if (block.number <= currentDistribution.endBlock || block.number > currentDistribution.endBlock + 50400) {
             return false;
         }
+
+        // check that the slate has no duplicates
+        if (_hasDuplicates(proposalIds_)) return false;
 
         uint256 gbc = currentDistribution.fundsAvailable;
         uint256 sum = 0;

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -184,12 +184,14 @@ abstract contract StandardFunding is Funding, IStandardFunding {
 
     /**
      * @notice Check an array of proposalIds for duplicate IDs.
+     * @dev    Counters incremented in unchecked block due to being bounded by array length.
      * @param  proposalIds_ Array of proposal Ids to check.
      * @return Boolean indicating the presence of a duplicate. True if it has a duplicate; false if not.
      */
     function _hasDuplicates(uint256[] calldata proposalIds_) internal pure returns (bool) {
-        for (uint i = 0; i < proposalIds_.length; ) {
-            for (uint j = i + 1; j < proposalIds_.length; ) {
+        uint256 numProposals = proposalIds_.length;
+        for (uint i = 0; i < numProposals; ) {
+            for (uint j = i + 1; j < numProposals; ) {
                 if (proposalIds_[i] == proposalIds_[j]) return true;
                 unchecked {
                     ++j;

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -87,11 +87,6 @@ abstract contract StandardFunding is Funding, IStandardFunding {
     /*** Distribution Management Functions ***/
     /*****************************************/
 
-    /// @inheritdoc IStandardFunding
-    function getSlateHash(uint256[] calldata proposalIds_) external pure returns (bytes32) {
-        return keccak256(abi.encode(proposalIds_));
-    }
-
     /**
      * @notice Set a new DistributionPeriod Id.
      * @dev    Increments the previous Id nonce by 1, and sets a checkpoint at the calling block.number.
@@ -251,6 +246,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         bool newTopSlate = currentSlateHash == 0 ||
             (currentSlateHash!= 0 && sum > _sumBudgetAllocated(fundedProposalSlates[currentSlateHash]));
 
+        // if slate of proposals is new top slate, update state
         if (newTopSlate) {
             uint256[] storage existingSlate = fundedProposalSlates[newSlateHash];
             for (uint i = 0; i < proposalIds_.length; ) {
@@ -500,6 +496,11 @@ abstract contract StandardFunding is Funding, IStandardFunding {
     /// @inheritdoc IStandardFunding
     function getFundedProposalSlate(bytes32 slateHash_) external view returns (uint256[] memory) {
         return fundedProposalSlates[slateHash_];
+    }
+
+    /// @inheritdoc IStandardFunding
+    function getSlateHash(uint256[] calldata proposalIds_) external pure returns (bytes32) {
+        return keccak256(abi.encode(proposalIds_));
     }
 
     /// @inheritdoc IStandardFunding

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -184,7 +184,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
 
     /**
      * @notice Check an array of proposalIds for duplicate IDs.
-     * @param  proposalIdSubset_ Array of proposal Ids to check.
+     * @param  proposalIds_ Array of proposal Ids to check.
      * @return Boolean indicating the presence of a duplicate. True if it has a duplicate; false if not.
      */
     function _hasDuplicates(uint256[] calldata proposalIds_) internal pure returns (bool) {

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -207,11 +207,10 @@ interface IStandardFunding {
 
     /**
      * @notice Get the funded proposal slate for a given distributionId, and slate hash
-     * @param  distributionId_ The distributionId of the distribution period to check.
      * @param  slateHash_      The slateHash to retrieve the funded proposals from.
      * @return                 The array of proposalIds that are in the funded slate hash.
      */
-    function getFundedProposalSlate(uint256 distributionId_, bytes32 slateHash_) external view returns (uint256[] memory);
+    function getFundedProposalSlate(bytes32 slateHash_) external view returns (uint256[] memory);
 
     /**
      * @notice Mapping of proposalIds to {Proposal} structs.

--- a/test/BurnWrappedToken.t.sol
+++ b/test/BurnWrappedToken.t.sol
@@ -16,14 +16,17 @@ contract BurnWrappedTokenTest is Test {
     address internal _ajnaAddress   = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079; // mainnet ajna token address
     address internal _tokenDeployer = 0x666cf594fB18622e1ddB91468309a7E194ccb799; // mainnet token deployer
     address internal _tokenHolder   = makeAddr("_tokenHolder");
-    uint256 _initialAjnaTokenSupply = 2_000_000_000 * 1e18;
+    uint256 _initialAjnaTokenSupply = 1_000_000_000 * 1e18;
 
     event Transfer(address indexed from, address indexed to, uint256 value);
     event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
     event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance);
 
     function setUp() external {
+        // create mainnet fork
         vm.createSelectFork(vm.envString("ETH_RPC_URL"));
+        // set fork block to block before token distribution
+        vm.rollFork(16527772);
 
         // reference mainnet deployment
         _token = AjnaToken(_ajnaAddress);
@@ -65,7 +68,7 @@ contract BurnWrappedTokenTest is Test {
         assertEq(_wrappedToken.balanceOf(address(_tokenDeployer)), 0);
 
         // check initial token supply
-        assertEq(_token.totalSupply(),        2_000_000_000 * 10 ** _token.decimals());
+        assertEq(_token.totalSupply(),        1_000_000_000 * 10 ** _token.decimals());
         assertEq(_wrappedToken.totalSupply(), 0);
 
         // transfer some tokens to the test address
@@ -89,7 +92,7 @@ contract BurnWrappedTokenTest is Test {
         assertEq(_wrappedToken.balanceOf(address(_tokenDeployer)), 0);
 
         // check token supply after wrapping
-        assertEq(_token.totalSupply(),        2_000_000_000 * 10 ** _token.decimals());
+        assertEq(_token.totalSupply(),        1_000_000_000 * 10 ** _token.decimals());
         assertEq(_wrappedToken.totalSupply(), tokensToWrap);
     }
 

--- a/test/StandardFunding.t.sol
+++ b/test/StandardFunding.t.sol
@@ -613,22 +613,22 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         potentialProposalSlate[1] = testProposals[6].proposalId;
         
         // ensure checkSlate won't allow if called before DistributionPeriod starts
-        bool prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(prposalSlate);
+        bool proposalSlateUpdated = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(proposalSlateUpdated);
 
         // skip to the DistributionPeriod
         vm.roll(_startBlock + 650_000);
 
         // ensure checkSlate won't allow if slate has a proposal that is not in topTenProposal (funding Stage)
-        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(prposalSlate);
+        proposalSlateUpdated = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(proposalSlateUpdated);
 
         // Updating potential Proposal Slate to include proposal that is in topTenProposal (funding Stage)
         potentialProposalSlate[1] = screenedProposals[1].proposalId;
 
         // ensure checkSlate won't allow exceeding the GBC
-        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(prposalSlate);
+        proposalSlateUpdated = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(proposalSlateUpdated);
         (, , , , , bytes32 slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0);
 
@@ -637,12 +637,12 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         potentialProposalSlate[0] = screenedProposals[3].proposalId;
         vm.expectEmit(true, true, false, true);
         emit FundedSlateUpdated(distributionId, _grantFund.getSlateHash(potentialProposalSlate));
-        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertTrue(prposalSlate);
+        proposalSlateUpdated = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertTrue(proposalSlateUpdated);
 
         // should not update slate if current funding slate is same as potentialProposalSlate 
-        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(prposalSlate);
+        proposalSlateUpdated = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(proposalSlateUpdated);
 
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
@@ -658,8 +658,8 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         potentialProposalSlate[1] = screenedProposals[4].proposalId;
         vm.expectEmit(true, true, false, true);
         emit FundedSlateUpdated(distributionId, _grantFund.getSlateHash(potentialProposalSlate));
-        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertTrue(prposalSlate);
+        proposalSlateUpdated = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertTrue(proposalSlateUpdated);
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0x1baa18a2d105ff81cc846882b7cc083ac252a82d2082db41156a83ae5d6a2436);
@@ -673,8 +673,8 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         potentialProposalSlate = new uint256[](2);
         potentialProposalSlate[0] = screenedProposals[0].proposalId;
         potentialProposalSlate[1] = screenedProposals[0].proposalId;
-        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(prposalSlate);
+        proposalSlateUpdated = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(proposalSlateUpdated);
 
         // ensure an additional update can be made to the optimized slate
         potentialProposalSlate = new uint256[](2);
@@ -682,8 +682,8 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         potentialProposalSlate[1] = screenedProposals[4].proposalId;
         vm.expectEmit(true, true, false, true);
         emit FundedSlateUpdated(distributionId, _grantFund.getSlateHash(potentialProposalSlate));
-        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertTrue(prposalSlate);
+        proposalSlateUpdated = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertTrue(proposalSlateUpdated);
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0x6d2192bdd3e08d75d683185db5947cd199403513241eddfa5cf8a36256f27c40);
@@ -697,8 +697,8 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         potentialProposalSlate = new uint256[](2);
         potentialProposalSlate[0] = screenedProposals[2].proposalId;
         potentialProposalSlate[1] = screenedProposals[3].proposalId;
-        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(prposalSlate);
+        proposalSlateUpdated = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(proposalSlateUpdated);
         // check funded proposal slate wasn't updated
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0x6d2192bdd3e08d75d683185db5947cd199403513241eddfa5cf8a36256f27c40);

--- a/test/StandardFunding.t.sol
+++ b/test/StandardFunding.t.sol
@@ -648,7 +648,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0x53dc2b0b8c3787b3384472e1d449bb35e20089a01306e21d59ec6d080cdcd1a8);
         // check funded proposal slate matches expected state
-        GrantFund.Proposal[] memory fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(distributionId, slateHash));
+        GrantFund.Proposal[] memory fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 1);
         assertEq(fundedProposalSlate[0].proposalId, screenedProposals[3].proposalId);
 
@@ -664,7 +664,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0x1baa18a2d105ff81cc846882b7cc083ac252a82d2082db41156a83ae5d6a2436);
         // check funded proposal slate matches expected state
-        fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(distributionId, slateHash));
+        fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
         assertEq(fundedProposalSlate[0].proposalId, screenedProposals[3].proposalId);
         assertEq(fundedProposalSlate[1].proposalId, screenedProposals[4].proposalId);
@@ -688,7 +688,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0x6d2192bdd3e08d75d683185db5947cd199403513241eddfa5cf8a36256f27c40);
         // check funded proposal slate matches expected state
-        fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(distributionId, slateHash));
+        fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
         assertEq(fundedProposalSlate[0].proposalId, screenedProposals[0].proposalId);
         assertEq(fundedProposalSlate[1].proposalId, screenedProposals[4].proposalId);
@@ -702,7 +702,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         // check funded proposal slate wasn't updated
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0x6d2192bdd3e08d75d683185db5947cd199403513241eddfa5cf8a36256f27c40);
-        fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(distributionId, slateHash));
+        fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
         assertEq(fundedProposalSlate[0].proposalId, screenedProposals[0].proposalId);
         assertEq(fundedProposalSlate[1].proposalId, screenedProposals[4].proposalId);

--- a/test/StandardFunding.t.sol
+++ b/test/StandardFunding.t.sol
@@ -613,22 +613,22 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         potentialProposalSlate[1] = testProposals[6].proposalId;
         
         // ensure checkSlate won't allow if called before DistributionPeriod starts
-        bool validSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(validSlate);
+        bool prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(prposalSlate);
 
         // skip to the DistributionPeriod
         vm.roll(_startBlock + 650_000);
 
         // ensure checkSlate won't allow if slate has a proposal that is not in topTenProposal (funding Stage)
-        validSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(validSlate);
+        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(prposalSlate);
 
         // Updating potential Proposal Slate to include proposal that is in topTenProposal (funding Stage)
         potentialProposalSlate[1] = screenedProposals[1].proposalId;
 
         // ensure checkSlate won't allow exceeding the GBC
-        validSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(validSlate);
+        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(prposalSlate);
         (, , , , , bytes32 slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0);
 
@@ -637,12 +637,12 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         potentialProposalSlate[0] = screenedProposals[3].proposalId;
         vm.expectEmit(true, true, false, true);
         emit FundedSlateUpdated(distributionId, _grantFund.getSlateHash(potentialProposalSlate));
-        validSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertTrue(validSlate);
+        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertTrue(prposalSlate);
 
         // should not update slate if current funding slate is same as potentialProposalSlate 
-        validSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(validSlate);
+        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(prposalSlate);
 
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
@@ -658,8 +658,8 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         potentialProposalSlate[1] = screenedProposals[4].proposalId;
         vm.expectEmit(true, true, false, true);
         emit FundedSlateUpdated(distributionId, _grantFund.getSlateHash(potentialProposalSlate));
-        validSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertTrue(validSlate);
+        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertTrue(prposalSlate);
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0x1baa18a2d105ff81cc846882b7cc083ac252a82d2082db41156a83ae5d6a2436);
@@ -669,14 +669,21 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertEq(fundedProposalSlate[0].proposalId, screenedProposals[3].proposalId);
         assertEq(fundedProposalSlate[1].proposalId, screenedProposals[4].proposalId);
 
+        // check that the slate isn't updated if a slate contains duplicate proposals
+        potentialProposalSlate = new uint256[](2);
+        potentialProposalSlate[0] = screenedProposals[0].proposalId;
+        potentialProposalSlate[1] = screenedProposals[0].proposalId;
+        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(prposalSlate);
+
         // ensure an additional update can be made to the optimized slate
         potentialProposalSlate = new uint256[](2);
         potentialProposalSlate[0] = screenedProposals[0].proposalId;
         potentialProposalSlate[1] = screenedProposals[4].proposalId;
         vm.expectEmit(true, true, false, true);
         emit FundedSlateUpdated(distributionId, _grantFund.getSlateHash(potentialProposalSlate));
-        validSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertTrue(validSlate);
+        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertTrue(prposalSlate);
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0x6d2192bdd3e08d75d683185db5947cd199403513241eddfa5cf8a36256f27c40);
@@ -690,8 +697,8 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         potentialProposalSlate = new uint256[](2);
         potentialProposalSlate[0] = screenedProposals[2].proposalId;
         potentialProposalSlate[1] = screenedProposals[3].proposalId;
-        validSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
-        assertFalse(validSlate);
+        prposalSlate = _grantFund.checkSlate(potentialProposalSlate, distributionId);
+        assertFalse(prposalSlate);
         // check funded proposal slate wasn't updated
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
         assertEq(slateHash, 0x6d2192bdd3e08d75d683185db5947cd199403513241eddfa5cf8a36256f27c40);


### PR DESCRIPTION
- Add `_hasDuplicates` method to check if a proposalId is duplicated in a a slate being checked by `checkSlate`
- https://github.com/sherlock-audit/2023-01-ajna-judging/issues/119
- Fixes BurnWrapper tests that were failing due to difference in expected mainnet token supply in the fork. Since half of the mainnet tokens were burned, the assertions needed to use the new post burn balance and use a fork block after the burn block.

Before change gas:
```
| Function Name                               | min             | avg    | median | max    | # calls |                                                                                                             
| checkSlate                                  | 843             | 42408  | 56364  | 78425  | 12      |

```

After change gas (3 different runs):
```
| Function Name                               | min             | avg    | median | max    | # calls |                                                                                                             
| checkSlate                                  | 843             | 40259  | 51664  | 78999  | 13      |                                                                                                             
| checkSlate                                  | 843             | 41690  | 70263  | 78999  | 13      |                                                                                                             
| checkSlate                                  | 843             | 40259  | 51664  | 78999  | 13      |                                                                                                             
```