### PR TITLE
Sherlock 124

### DIFF
--- a/src/grants/base/ExtraordinaryFunding.sol
+++ b/src/grants/base/ExtraordinaryFunding.sol
@@ -46,6 +46,9 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
             revert ExecuteExtraordinaryProposalInvalid();
         }
 
+        // check tokens requested are available for claiming from the treasury
+        if (proposal.tokensRequested > getSliceOfTreasury(Maths.WAD - _getMinimumThresholdPercentage())) revert ExtraordinaryFundingProposalInvalid();
+
         // check if the proposal has received more votes than minimumThreshold and tokensRequestedPercentage of all tokens
         if (proposal.votesReceived >= proposal.tokensRequested + getSliceOfNonTreasury(_getMinimumThresholdPercentage())) {
             proposal.succeeded = true;
@@ -82,7 +85,7 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
 
         uint256 totalTokensRequested = _validateCallDatas(targets_, values_, calldatas_);
 
-        // check tokens requested is within limits
+        // check tokens requested are available for claiming from the treasury
         if (totalTokensRequested > getSliceOfTreasury(Maths.WAD - _getMinimumThresholdPercentage())) revert ExtraordinaryFundingProposalInvalid();
 
         // store newly created proposal

--- a/src/grants/base/ExtraordinaryFunding.sol
+++ b/src/grants/base/ExtraordinaryFunding.sol
@@ -46,9 +46,6 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
             revert ExecuteExtraordinaryProposalInvalid();
         }
 
-        // check tokens requested are available for claiming from the treasury
-        if (proposal.tokensRequested > getSliceOfTreasury(Maths.WAD - _getMinimumThresholdPercentage())) revert ExtraordinaryFundingProposalInvalid();
-
         // check if the proposal has received more votes than minimumThreshold and tokensRequestedPercentage of all tokens
         if (proposal.votesReceived >= proposal.tokensRequested + getSliceOfNonTreasury(_getMinimumThresholdPercentage())) {
             proposal.succeeded = true;
@@ -56,6 +53,9 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
             proposal.succeeded = false;
             revert ExecuteExtraordinaryProposalInvalid();
         }
+
+        // check tokens requested are available for claiming from the treasury
+        if (proposal.tokensRequested > getSliceOfTreasury(Maths.WAD - _getMinimumThresholdPercentage())) revert ExtraordinaryFundingProposalInvalid();
 
         fundedExtraordinaryProposals.push(proposal.proposalId);
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Adds the tokensRequested limit used in `proposeExtraordinary` to `executeExtraordinary` in the case that other extraordinary proposals were executed after a proposal was created. 
* Fixes: https://github.com/sherlock-audit/2023-01-ajna-judging/issues/124

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
Proposing an extraordinary funding proposal with the ExtraordinaryFunding.proposeExtraordinary function verifies that the requested token amount is within (less than) a certain limit in ExtraordinaryFunding.sol#L86. The limit is based on the treasury Ajna token balance and decreases with an increasing number of funded extraordinary proposals. A maximum number of 10 extraordinary proposals can be funded.

If multiple extraordinary proposals are proposed while the number of funded proposals is unchanged, the limit for the tokens requested is the same for those proposals. At a later time, if those proposals pass voting, the proposals are executed and receive the requested (stale) token amount.
Impact

The requested token amount of an extraordinary proposal is not checked when executing if it's within the same limits imposed by L86.

If another extraordinary proposal was successfully funded and executed in the meantime of the 1 month voting period for the proposal, the limit for the requested token amount is already lower than the proposal.tokensRequested amount.

This means that if multiple extraordinary proposals are proposed at a similar time and pass voting, the tokensRequested amount is stale and potentially too much.

# Contract size
## Pre Change
<PASTE_OUTPUT_HERE>
## Post Change
<PASTE_OUTPUT_HERE>

# Gas usage
## Pre Change
<PASTE_OUTPUT_HERE>
## Post Change
<PASTE_OUTPUT_HERE>





