### PR TITLE
Sherlock 3

### DIFF
--- a/src/token/AjnaToken.sol
+++ b/src/token/AjnaToken.sol
@@ -44,7 +44,6 @@ contract AjnaToken is ERC20, ERC20Burnable, ERC20Permit, ERC20Votes {
      *  @notice Called by an owner of AJNA tokens to enable their tokens to be transferred by a spender address without making a seperate permit call
      *  @param  from_     The address of the current owner of the tokens
      *  @param  to_       The address of the new owner of the tokens
-     *  @param  spender_  The address of the third party who will execute the transaction involving an owners tokens
      *  @param  value_    The amount of tokens to transfer
      *  @param  deadline_ The unix timestamp by which the permit must be called
      *  @param  v_        Component of secp256k1 signature
@@ -52,9 +51,9 @@ contract AjnaToken is ERC20, ERC20Burnable, ERC20Permit, ERC20Votes {
      *  @param  s_        Component of secp256k1 signature
      */
     function transferFromWithPermit(
-        address from_, address to_, address spender_, uint256 value_, uint256 deadline_, uint8 v_, bytes32 r_, bytes32 s_
+        address from_, address to_, uint256 value_, uint256 deadline_, uint8 v_, bytes32 r_, bytes32 s_
     ) external {
-        permit(from_, spender_, value_, deadline_, v_, r_, s_);
+        permit(from_, msg.sender, value_, deadline_, v_, r_, s_);
         transferFrom(from_, to_, value_);
     }
 }

--- a/test/AjnaToken.t.sol
+++ b/test/AjnaToken.t.sol
@@ -133,7 +133,7 @@ contract AjnaTokenTest is Test {
         digest = _sigUtils.getTypedDataHash(permit);
         (v, r, s) = vm.sign(ownerPrivateKey, digest);
 
-        _token.transferFromWithPermit(owner, newOwner, spender, amount_, permit.deadline, v, r, s);
+        _token.transferFromWithPermit(owner, newOwner, amount_, permit.deadline, v, r, s);
         // check owner and spender balances after 2nd transfer with permit
         assertEq(_token.balanceOf(owner),    0);
         assertEq(_token.balanceOf(spender),  0);
@@ -153,7 +153,7 @@ contract AjnaTokenTest is Test {
         (v, r, s) = vm.sign(ownerPrivateKey, digest);
 
         vm.expectRevert("ERC20: transfer amount exceeds balance");
-        _token.transferFromWithPermit(owner, newOwner, spender, 1, permit.deadline, v, r, s);
+        _token.transferFromWithPermit(owner, newOwner, 1, permit.deadline, v, r, s);
     }
 
     /*********************/


### PR DESCRIPTION
- Prevent front running of `transferFromWithPermit` as mentioned in sherlock 3 https://github.com/sherlock-audit/2023-01-ajna-judging/issues/3 
- Someone could snipe the tx in the mempool, strip out the valid signature, and send a new transaction to the relaying spender with an updated to address and the valid signature
- Burn wrapper test fix is in [pr 38](https://github.com/ajna-finance/ecosystem-coordination/pull/38)