### PR TITLE
Sherlock 64

### DIFF
--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -128,17 +128,15 @@ contract GrantFund is IGrantFund, ExtraordinaryFunding, StandardFunding {
 
                 // this is the first time a voter has attempted to vote this period
                 if (voter.votingWeight == 0) {
-                    voter.votingWeight = Maths.wpow(_getVotesSinceSnapshot(account_, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
-                    voter.budgetRemaining = int256(voter.votingWeight);
+                    // voter.votingWeight = Maths.wpow(_getVotesSinceSnapshot(account_, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
+                    voter.votingWeight    = _getVotesSinceSnapshot(account_, screeningPeriodEndBlock - 33, screeningPeriodEndBlock);
+                    voter.budgetRemaining = Maths.wpow(voter.votingWeight, 2);
                 }
 
                 // amount of quadratic budget to allocated to the proposal
-                int256 budgetAllocation = abi.decode(params_, (int256));
+                int256 votes = abi.decode(params_, (int256));
 
-                // check if the voter has enough budget remaining to allocate to the proposal
-                if (Maths.abs(budgetAllocation) > voter.budgetRemaining) revert InsufficientBudget();
-
-                votesCast_ = _fundingVote(proposal, account_, voter, budgetAllocation);
+                votesCast_ = _fundingVote(proposal, account_, voter, votes);
             }
         }
 

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -105,9 +105,9 @@ contract GrantFund is IGrantFund, ExtraordinaryFunding, StandardFunding {
         uint256 screeningPeriodEndBlock = currentDistribution.endBlock - 72000;
 
         // this is the first time a voter has attempted to vote this period
-        if (voter.votingWeight == 0) {
-            voter.votingWeight    = _getVotesSinceSnapshot(msg.sender, screeningPeriodEndBlock - 33, screeningPeriodEndBlock);
-            voter.budgetRemaining = Maths.wpow(voter.votingWeight, 2);
+        if (voter.votingPower == 0) {
+            voter.votingPower    = Maths.wpow(_getVotesSinceSnapshot(msg.sender, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
+            voter.remainingVotingPower = voter.votingPower;
         }
 
         for (uint256 i = 0; i < voteParams_.length; ) {
@@ -156,9 +156,9 @@ contract GrantFund is IGrantFund, ExtraordinaryFunding, StandardFunding {
                 QuadraticVoter storage voter = quadraticVoters[currentDistribution.id][account_];
 
                 // this is the first time a voter has attempted to vote this period
-                if (voter.votingWeight == 0) {
-                    voter.votingWeight    = _getVotesSinceSnapshot(account_, screeningPeriodEndBlock - 33, screeningPeriodEndBlock);
-                    voter.budgetRemaining = Maths.wpow(voter.votingWeight, 2);
+                if (voter.votingPower == 0) {
+                    voter.votingPower    = Maths.wpow(_getVotesSinceSnapshot(msg.sender, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
+                    voter.remainingVotingPower = voter.votingPower;
                 }
 
                 // decode the amount of votes to allocated to the proposal
@@ -197,15 +197,13 @@ contract GrantFund is IGrantFund, ExtraordinaryFunding, StandardFunding {
         else if (keccak256(params_) == keccak256(bytes("Funding"))) {
             QuadraticVoter memory voter = quadraticVoters[currentDistribution.id][account_];
 
-            // TODO: fix voter available votes calculation
             // voter has already allocated some of their budget this period
-            if (voter.votingWeight != 0) {
-                // take the sqrt of the remaining budget to retrieve available votes
-                availableVotes_ = Maths.sqrt(voter.budgetRemaining);
+            if (voter.votingPower != 0) {
+                availableVotes_ = voter.remainingVotingPower;
             }
             // this is the first time a voter has attempted to vote this period
             else {
-                availableVotes_ = _getVotesSinceSnapshot(account_, currentDistribution.endBlock - 72033, currentDistribution.endBlock - 72000);
+                availableVotes_ = Maths.wpow(_getVotesSinceSnapshot(account_, currentDistribution.endBlock - 72033, currentDistribution.endBlock - 72000), 2);
             }
         }
         else {

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -98,6 +98,12 @@ contract GrantFund is IGrantFund, ExtraordinaryFunding, StandardFunding {
     /*** Voting Functions ***/
     /************************/
 
+    /**
+     * @notice Cast an array of funding votes in one transaction.
+     * @dev    Calls out to StandardFunding._fundingVote().
+     * @param voteParams_ The array of votes on proposals to cast.
+     * @return votesCast_ The total number of votes cast across all of the proposals.
+     */
     function fundingVotesMulti(FundingVoteParams[] memory voteParams_) external returns (uint256 votesCast_) {
         uint256 currentDistributionId = distributionIdCheckpoints.latest();
         QuarterlyDistribution storage currentDistribution = distributions[currentDistributionId];
@@ -106,13 +112,15 @@ contract GrantFund is IGrantFund, ExtraordinaryFunding, StandardFunding {
 
         // this is the first time a voter has attempted to vote this period
         if (voter.votingPower == 0) {
-            voter.votingPower    = Maths.wpow(_getVotesSinceSnapshot(msg.sender, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
+            voter.votingPower          = Maths.wpow(_getVotesSinceSnapshot(msg.sender, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
             voter.remainingVotingPower = voter.votingPower;
         }
 
-        for (uint256 i = 0; i < voteParams_.length; ) {
+        uint256 numVotesCast = voteParams_.length;
+        for (uint256 i = 0; i < numVotesCast; ) {
             Proposal storage proposal = standardFundingProposals[voteParams_[i].proposalId];
 
+            // cast each successive vote
             votesCast_ += _fundingVote(
                 currentDistribution,
                 proposal,
@@ -157,7 +165,7 @@ contract GrantFund is IGrantFund, ExtraordinaryFunding, StandardFunding {
 
                 // this is the first time a voter has attempted to vote this period
                 if (voter.votingPower == 0) {
-                    voter.votingPower    = Maths.wpow(_getVotesSinceSnapshot(msg.sender, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
+                    voter.votingPower          = Maths.wpow(_getVotesSinceSnapshot(msg.sender, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
                     voter.remainingVotingPower = voter.votingPower;
                 }
 

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -165,7 +165,7 @@ contract GrantFund is IGrantFund, ExtraordinaryFunding, StandardFunding {
 
                 // this is the first time a voter has attempted to vote this period
                 if (voter.votingPower == 0) {
-                    voter.votingPower          = Maths.wpow(_getVotesSinceSnapshot(msg.sender, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
+                    voter.votingPower          = Maths.wpow(_getVotesSinceSnapshot(account_, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
                     voter.remainingVotingPower = voter.votingPower;
                 }
 

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -559,7 +559,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
 
     /// @inheritdoc IStandardFunding
     function getFundingPowerVotes(uint256 votingPower) external pure returns (uint256) {
-        return Maths.sqrt(votingPower) * 10**9;
+        return Maths.wsqrt(votingPower);
     }
 
     /// @inheritdoc IStandardFunding

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -558,6 +558,11 @@ abstract contract StandardFunding is Funding, IStandardFunding {
     }
 
     /// @inheritdoc IStandardFunding
+    function getFundingPowerVotes(uint256 votingPower) external pure returns (uint256) {
+        return Maths.sqrt(votingPower) * 10**9;
+    }
+
+    /// @inheritdoc IStandardFunding
     function getSlateHash(uint256[] calldata proposalIds_) external pure returns (bytes32) {
         return keccak256(abi.encode(proposalIds_));
     }

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -163,11 +163,11 @@ abstract contract StandardFunding is Funding, IStandardFunding {
     }
 
     /**
-     * @notice Calculates the sum of quadratic budgets allocated to a list of proposals.
+     * @notice Calculates the sum of funding votes allocated to a list of proposals.
      * @param  proposalIdSubset_ Array of proposal Ids to sum.
-     * @return sum_ The sum of the budget across the given proposals.
+     * @return sum_ The sum of the funding votes across the given proposals.
      */
-    function _sumBudgetAllocated(uint256[] memory proposalIdSubset_) internal view returns (uint256 sum_) {
+    function _sumProposalFundingVotes(uint256[] memory proposalIdSubset_) internal view returns (uint256 sum_) {
         for (uint i = 0; i < proposalIdSubset_.length;) {
             sum_ += uint256(standardFundingProposals[proposalIdSubset_[i]].fundingVotesReceived);
 
@@ -244,7 +244,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
 
         // check if slate of proposals is new top slate
         bool newTopSlate = currentSlateHash == 0 ||
-            (currentSlateHash!= 0 && sum > _sumBudgetAllocated(fundedProposalSlates[currentSlateHash]));
+            (currentSlateHash!= 0 && sum > _sumProposalFundingVotes(fundedProposalSlates[currentSlateHash]));
 
         // if slate of proposals is new top slate, update state
         if (newTopSlate) {
@@ -438,10 +438,10 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         // calculate the cumulative cost of all votes made by the voter
         uint256 cumulativeVotePowerUsed = _sumSquareOfVotesCast(voter_.votesCast);
 
-        // check that the voter has enough budget remaining to cast the vote
+        // check that the voter has enough voting power remaining to cast the vote
         if (cumulativeVotePowerUsed > voter_.votingPower) revert InsufficientVotingPower();
 
-        // update voter budget accumulator
+        // update voter voting power accumulator
         voter_.remainingVotingPower = voter_.votingPower - cumulativeVotePowerUsed;
 
         // calculate the change in voting power used by the voter in this vote in order to accurately track the total voting power used in the funding stage

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -383,39 +383,10 @@ abstract contract StandardFunding is Funding, IStandardFunding {
     /*** Voting Functions ***/
     /************************/
 
-    // function fundingVotesMulti(FundingVoteParams[] memory voteParams_) external returns (uint256 votesCast_) {
-    //     uint256 currentDistributionId = distributionIdCheckpoints.latest();
-    //     QuarterlyDistribution storage currentDistribution = distributions[currentDistributionId];
-    //     QuadraticVoter storage voter = quadraticVoters[currentDistribution.id][msg.sender];
-    //     uint256 screeningPeriodEndBlock = currentDistribution.endBlock - 72000;
-
-    //     // this is the first time a voter has attempted to vote this period
-    //     if (voter.votingPower == 0) {
-            // voter.votingPower    = Maths.wpow(_getVotesSinceSnapshot(msg.sender, screeningPeriodEndBlock - 33, screeningPeriodEndBlock), 2);
-            // voter.remainingVotingPower = voter.votingPower;
-    //     }
-
-    //     for (uint256 i = 0; i < voteParams_.length; ) {
-    //         Proposal storage proposal = standardFundingProposals[voteParams_[i].proposalId];
-
-    //         votesCast_ += _fundingVote(
-    //             currentDistribution,
-    //             proposal,
-    //             msg.sender,
-    //             voter,
-    //             voteParams_[i]
-    //         );
-
-    //         unchecked {
-    //             ++i;
-    //         }
-    //     }
-    // }
-
     /**
      * @notice Sum the square of each vote cast by a voter.
-     * @param  votesCast_ The array of votes cast by a voter.
      * @dev    Used to calculate if a voter has enough voting power to cast their votes.
+     * @param  votesCast_           The array of votes cast by a voter.
      * @return votesCastSumSquared_ The sum of the square of each vote cast.
      */
     function _sumSquareOfVotesCast(FundingVoteParams[] memory votesCast_) internal pure returns (uint256 votesCastSumSquared_) {
@@ -432,11 +403,11 @@ abstract contract StandardFunding is Funding, IStandardFunding {
     /**
      * @notice Vote on a proposal in the funding stage of the Distribution Period.
      * @dev    Votes can be allocated to multiple proposals, quadratically, for or against.
-     * @param  currentDistribution_ The current distribution period.
-     * @param  proposal_  The current proposal being voted upon.
-     * @param  account_   The voting account.
-     * @param  voter_     The voter data struct tracking available votes.
-     * @param  voteParams_ The amount of votes being allocated to the proposal. Not squared. If less than 0, vote is against.
+     * @param  currentDistribution_  The current distribution period.
+     * @param  proposal_             The current proposal being voted upon.
+     * @param  account_              The voting account.
+     * @param  voter_                The voter data struct tracking available votes.
+     * @param  voteParams_           The amount of votes being allocated to the proposal. Not squared. If less than 0, vote is against.
      * @return incrementalVotesUsed_ The amount of funding stage votes allocated to the proposal.
      */
     function _fundingVote(QuarterlyDistribution storage currentDistribution_, Proposal storage proposal_, address account_, QuadraticVoter storage voter_, FundingVoteParams memory voteParams_) internal returns (uint256 incrementalVotesUsed_) {
@@ -662,12 +633,13 @@ abstract contract StandardFunding is Funding, IStandardFunding {
      * @param voteParams_ The array of FundingVoteParams structs to search.
      * @return index_ The index of the proposalId in the array, else -1.
      */
-    function _findProposalIndexOfVotesCast(uint256 proposalId, FundingVoteParams[] memory voteParams_) internal pure returns (int256 index_) {
+    function _findProposalIndexOfVotesCast(uint256 proposalId_, FundingVoteParams[] memory voteParams_) internal pure returns (int256 index_) {
         index_ = -1; // default value indicating proposalId not in the array
 
-        for (int256 i = 0; i < int256(voteParams_.length);) {
+        int256 numVotesCast = int256(voteParams_.length);
+        for (int256 i = 0; i < numVotesCast; ) {
             //slither-disable-next-line incorrect-equality
-            if (voteParams_[uint256(i)].proposalId == proposalId) {
+            if (voteParams_[uint256(i)].proposalId == proposalId_) {
                 index_ = i;
                 break;
             }

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -288,12 +288,6 @@ abstract contract StandardFunding is Funding, IStandardFunding {
             ),
             currentDistribution.fundingVotePowerCast
         ) / 10;
-
-        // // TODO: multiply before dividing?
-        // Maths.wdiv(
-        //     Maths.wmul(currentDistribution.fundsAvailable, currentDistribution.fundingVotePowerCast),
-        //     voter.votesUsed
-        // ) / 10;
     }
 
     /// @inheritdoc IStandardFunding

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -111,9 +111,10 @@ interface IStandardFunding {
      * @notice Contains information about voters during a distribution period's funding stage.
      */
     struct QuadraticVoter {
-        uint256 votingWeight;    // amount of votes originally available to the voter // TODO: is this necessary?
-        uint256 budgetRemaining; // remaining voting budget in the given period, equal to the sum of the square of their initial votes
-        uint256 votesUsed;       // number of unsquared votes used
+        uint256 votingWeight;    // amount of votes originally available to the voter // TODO: rename to votingPower
+        uint256 budgetRemaining; // remaining voting budget in the given period, equal to the sum of the square of their initial votes // TODO: rename to remainingVotingPower
+        // uint256 votesUsed;       // number of unsquared votes used
+        uint256[] votesCast;     // array of votes cast by the voter
     }
 
     /*****************************************/
@@ -248,7 +249,7 @@ interface IStandardFunding {
      * @param  account_        The address of the voter to check.
      * @return votingWeight    The voter's voting weight in the funding round. Equal to the square of their tokens in the voting snapshot.
      * @return budgetRemaining The voter's remaining quadratic vote budget in the given distribution period's funding round.
-     * @return votesCast       The voter's total votes cast in the given distribution period's funding round.
+     * @return votesCast       The voter's number of proposals voted on in the funding stage.
      */
     function getVoterInfo(uint256 distributionId_, address account_) external view returns (uint256, uint256, uint256);
 

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -124,8 +124,8 @@ interface IStandardFunding {
      * @notice Contains information about voters during a distribution period's funding stage.
      */
     struct QuadraticVoter {
-        uint256 votingPower;           // amount of votes originally available to the voter
-        uint256 remainingVotingPower;  // remaining voting budget in the given period, equal to the sum of the square of their initial votes
+        uint256 votingPower;           // amount of votes originally available to the voter, equal to the sum of the square of their initial votes
+        uint256 remainingVotingPower;  // remaining voting power in the given period
         FundingVoteParams[] votesCast; // array of votes cast by the voter
     }
 

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -182,6 +182,14 @@ interface IStandardFunding {
     /**********************/
 
     /**
+     * @notice Retrieve the delegate reward accrued to a voter in a given distribution period.
+     * @param  distributionId_ The distributionId to calculate rewards for.
+     * @param  voter_          The address of the voter to calculate rewards for.
+     * @return rewards_        The rewards earned by the voter for voting in that distribution period.
+     */
+    function getDelegateReward(uint256 distributionId_, address voter_) external view returns (uint256 rewards_);
+
+    /**
      * @notice Retrieve the QuarterlyDistribution distributionId at a given block.
      * @param  blockNumber The block number to check.
      * @return             The distributionId at the given block.

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -28,6 +28,11 @@ interface IStandardFunding {
     error FinalizeDistributionInvalid();
 
     /**
+     * @notice User attempted to change the direction of a subsequent funding vote on the same proposal.
+     */
+    error FundingVoteInvalid();
+
+    /**
      * @notice User attempted to vote with more qvBudget than was available to them.
      */
     error InsufficientBudget();
@@ -108,13 +113,20 @@ interface IStandardFunding {
     }
 
     /**
+     * @notice Contains information about voters during a vote made by a QuadraticVoter in the Funding stage of a distribution period.
+     */
+    struct FundingVoteParams {
+        uint256 proposalId;
+        int256 votesUsed;
+    }
+
+    /**
      * @notice Contains information about voters during a distribution period's funding stage.
      */
     struct QuadraticVoter {
         uint256 votingWeight;    // amount of votes originally available to the voter // TODO: rename to votingPower
         uint256 budgetRemaining; // remaining voting budget in the given period, equal to the sum of the square of their initial votes // TODO: rename to remainingVotingPower
-        // uint256 votesUsed;       // number of unsquared votes used
-        uint256[] votesCast;     // array of votes cast by the voter
+        FundingVoteParams[] votesCast;     // array of votes cast by the voter
     }
 
     /*****************************************/

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -92,24 +92,24 @@ interface IStandardFunding {
      * @notice Contains proposals that made it through the screening process to the funding stage.
      */
     struct QuarterlyDistribution {
-        uint256 id;                  // id of the current quarterly distribution
-        uint256 fundingVotesCast;  // total number of votes cast in funding stage that quarter
-        uint256 startBlock;          // block number of the quarterly distributions start
-        uint256 endBlock;            // block number of the quarterly distributions end
-        uint256 fundsAvailable;      // maximum fund (including delegate reward) that can be taken out that quarter   
-        bytes32 fundedSlateHash;     // hash of list of proposals to fund
+        uint256 id;                   // id of the current quarterly distribution
+        uint256 fundingVotePowerCast; // total number of voting power allocated in funding stage that quarter
+        uint256 startBlock;           // block number of the quarterly distributions start
+        uint256 endBlock;             // block number of the quarterly distributions end
+        uint256 fundsAvailable;       // maximum fund (including delegate reward) that can be taken out that quarter
+        bytes32 fundedSlateHash;      // hash of list of proposals to fund
     }
 
     /**
      * @notice Contains information about proposals in a distribution period.
      */
     struct Proposal {
-        uint256 proposalId;        // OZ.Governor proposalId. Hash of proposeStandard inputs
-        uint256 distributionId;    // Id of the distribution period in which the proposal was made
-        uint256 votesReceived;     // accumulator of screening votes received by a proposal
-        uint256 tokensRequested;   // number of Ajna tokens requested in the proposal
+        uint256 proposalId;           // OZ.Governor proposalId. Hash of proposeStandard inputs
+        uint256 distributionId;       // Id of the distribution period in which the proposal was made
+        uint256 votesReceived;        // accumulator of screening votes received by a proposal
+        uint256 tokensRequested;      // number of Ajna tokens requested in the proposal
         int256  fundingVotesReceived; // accumulator of funding votes allocated to the proposal.
-        bool    executed;          // whether the proposal has been executed
+        bool    executed;             // whether the proposal has been executed
     }
 
     /**
@@ -124,9 +124,9 @@ interface IStandardFunding {
      * @notice Contains information about voters during a distribution period's funding stage.
      */
     struct QuadraticVoter {
-        uint256 votingWeight;    // amount of votes originally available to the voter // TODO: rename to votingPower
-        uint256 budgetRemaining; // remaining voting budget in the given period, equal to the sum of the square of their initial votes // TODO: rename to remainingVotingPower
-        FundingVoteParams[] votesCast;     // array of votes cast by the voter
+        uint256 votingPower;           // amount of votes originally available to the voter
+        uint256 remainingVotingPower;  // remaining voting budget in the given period, equal to the sum of the square of their initial votes // TODO: rename to remainingVotingPower
+        FundingVoteParams[] votesCast; // array of votes cast by the voter
     }
 
     /*****************************************/
@@ -259,9 +259,9 @@ interface IStandardFunding {
      * @notice Get the current state of a given voter in the funding stage.
      * @param  distributionId_ The distributionId of the distribution period to check.
      * @param  account_        The address of the voter to check.
-     * @return votingWeight    The voter's voting weight in the funding round. Equal to the square of their tokens in the voting snapshot.
-     * @return budgetRemaining The voter's remaining quadratic vote budget in the given distribution period's funding round.
-     * @return votesCast       The voter's number of proposals voted on in the funding stage.
+     * @return votingPower          The voter's voting power in the funding round. Equal to the square of their tokens in the voting snapshot.
+     * @return remainingVotingPower The voter's remaining quadratic voting power in the given distribution period's funding round.
+     * @return votesCast            The voter's number of proposals voted on in the funding stage.
      */
     function getVoterInfo(uint256 distributionId_, address account_) external view returns (uint256, uint256, uint256);
 

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -235,6 +235,15 @@ interface IStandardFunding {
     function getFundedProposalSlate(bytes32 slateHash_) external view returns (uint256[] memory);
 
     /**
+     * @notice Get the number of discrete votes that can be cast on proposals given a specified voting power.
+     * @dev    This is calculated by taking the square root of the voting power, and adjusting for WAD decimals.
+     * @dev    This approach results in precision loss, and prospective users should be careful.
+     * @param  votingPower     The provided voting power to calculate discrete votes for.
+     * @return                 The square root of the votingPower as a WAD.
+     */
+    function getFundingPowerVotes(uint256 votingPower) external pure returns (uint256);
+
+    /**
      * @notice Mapping of proposalIds to {Proposal} structs.
      * @param  proposalId_       The proposalId to retrieve the Proposal struct for.
      * @return proposalId        The retrieved struct's proposalId.

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -125,7 +125,7 @@ interface IStandardFunding {
      */
     struct QuadraticVoter {
         uint256 votingPower;           // amount of votes originally available to the voter
-        uint256 remainingVotingPower;  // remaining voting budget in the given period, equal to the sum of the square of their initial votes // TODO: rename to remainingVotingPower
+        uint256 remainingVotingPower;  // remaining voting budget in the given period, equal to the sum of the square of their initial votes
         FundingVoteParams[] votesCast; // array of votes cast by the voter
     }
 

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -88,7 +88,7 @@ interface IStandardFunding {
      */
     struct QuarterlyDistribution {
         uint256 id;                  // id of the current quarterly distribution
-        uint256 quadraticVotesCast;  // total number of votes cast in funding stage that quarter
+        uint256 fundingVotesCast;  // total number of votes cast in funding stage that quarter
         uint256 startBlock;          // block number of the quarterly distributions start
         uint256 endBlock;            // block number of the quarterly distributions end
         uint256 fundsAvailable;      // maximum fund (including delegate reward) that can be taken out that quarter   
@@ -103,7 +103,7 @@ interface IStandardFunding {
         uint256 distributionId;    // Id of the distribution period in which the proposal was made
         uint256 votesReceived;     // accumulator of screening votes received by a proposal
         uint256 tokensRequested;   // number of Ajna tokens requested in the proposal
-        int256  qvBudgetAllocated; // accumulator of QV budget allocated
+        int256  fundingVotesReceived; // accumulator of funding votes allocated to the proposal.
         bool    executed;          // whether the proposal has been executed
     }
 
@@ -111,8 +111,9 @@ interface IStandardFunding {
      * @notice Contains information about voters during a distribution period's funding stage.
      */
     struct QuadraticVoter {
-        uint256 votingWeight;   // amount of votes originally available to the voter
-        int256 budgetRemaining; // remaining voting budget in the given period
+        uint256 votingWeight;    // amount of votes originally available to the voter // TODO: is this necessary?
+        uint256 budgetRemaining; // remaining voting budget in the given period, equal to the sum of the square of their initial votes
+        uint256 votesUsed;       // number of unsquared votes used
     }
 
     /*****************************************/
@@ -197,7 +198,7 @@ interface IStandardFunding {
      * @notice Mapping of distributionId to {QuarterlyDistribution} struct.
      * @param  distributionId_ The distributionId to retrieve the QuarterlyDistribution struct for.
      * @return distributionId     The retrieved struct's distributionId.
-     * @return quadraticVotesCast The total number of votes cast in the distribution period's funding round.
+     * @return fundingVotesCast The total number of votes cast in the distribution period's funding round.
      * @return startBlock         The block number of the distribution period's start.
      * @return endBlock           The block number of the distribution period's end.
      * @return fundsAvailable     The maximum amount of funds that can be taken out of the distribution period.
@@ -239,8 +240,9 @@ interface IStandardFunding {
      * @param  account_        The address of the voter to check.
      * @return votingWeight    The voter's voting weight in the funding round. Equal to the square of their tokens in the voting snapshot.
      * @return budgetRemaining The voter's remaining quadratic vote budget in the given distribution period's funding round.
+     * @return votesCast       The voter's total votes cast in the given distribution period's funding round.
      */
-    function getVoterInfo(uint256 distributionId_, address account_) external view returns (uint256, int256);
+    function getVoterInfo(uint256 distributionId_, address account_) external view returns (uint256, uint256, uint256);
 
     /**
      * @notice Get the current maximum possible distribution of Ajna tokens that will be released from the treasury this quarter.

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -33,9 +33,9 @@ interface IStandardFunding {
     error FundingVoteInvalid();
 
     /**
-     * @notice User attempted to vote with more qvBudget than was available to them.
+     * @notice User attempted to vote with more voting power than was available to them.
      */
-    error InsufficientBudget();
+    error InsufficientVotingPower();
 
     /**
      * @notice Delegatee attempted to claim delegate reward before the challenge period ended.

--- a/src/grants/libraries/Maths.sol
+++ b/src/grants/libraries/Maths.sol
@@ -9,11 +9,16 @@ library Maths {
         return x >= 0 ? x : -x;
     }
 
-    // babylonian method (https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method)
-    function sqrt(uint y) internal pure returns (uint z) {
+    /**
+     * @notice Returns the square root of a WAD, as a WAD.
+     * @dev Utilizes the babylonian method: https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method.
+     * @param y The WAD to take the square root of.
+     * @return z The square root of the WAD, as a WAD.
+     */
+    function wsqrt(uint256 y) internal pure returns (uint256 z) {
         if (y > 3) {
             z = y;
-            uint x = y / 2 + 1;
+            uint256 x = y / 2 + 1;
             while (x < z) {
                 z = x;
                 x = (y / x + x) / 2;
@@ -21,6 +26,8 @@ library Maths {
         } else if (y != 0) {
             z = 1;
         }
+        // convert z to a WAD
+        z = z * 10**9;
     }
 
     function wmul(uint256 x, uint256 y) internal pure returns (uint256) {

--- a/src/grants/libraries/Maths.sol
+++ b/src/grants/libraries/Maths.sol
@@ -9,6 +9,20 @@ library Maths {
         return x >= 0 ? x : -x;
     }
 
+    // babylonian method (https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method)
+    function sqrt(uint y) internal pure returns (uint z) {
+        if (y > 3) {
+            z = y;
+            uint x = y / 2 + 1;
+            while (x < z) {
+                z = x;
+                x = (y / x + x) / 2;
+            }
+        } else if (y != 0) {
+            z = 1;
+        }
+    }
+
     function wmul(uint256 x, uint256 y) internal pure returns (uint256) {
         return (x * y + 10**18 / 2) / 10**18;
     }
@@ -37,4 +51,5 @@ library Maths {
             }
         }
     }
+
 }

--- a/test/Maths.t.sol
+++ b/test/Maths.t.sol
@@ -53,6 +53,14 @@ contract MathsTest is Test {
 
     function testScaleConversions() external {
         assertEq(Maths.wad(153), 153 * 1e18);
-    } 
+    }
+
+    function testSqrt() external {
+        assertEq(Maths.sqrt(Maths.wad(100)) * 10**9, 10 * 1e18);
+        assertEq(Maths.sqrt(Maths.wad(100)) * 10**9, 10 * 1e18);
+        assertEq(Maths.sqrt(Maths.wad(25)) * 10**9, 5 * 1e18);
+        assertEq(Maths.sqrt(11_000.143012091382543917 * 1e18) * 10**9, 104.881566598000000000 * 1e18);
+        assertEq(Maths.sqrt(100), 10);
+    }
 
 }

--- a/test/Maths.t.sol
+++ b/test/Maths.t.sol
@@ -56,11 +56,9 @@ contract MathsTest is Test {
     }
 
     function testSqrt() external {
-        assertEq(Maths.sqrt(Maths.wad(100)) * 10**9, 10 * 1e18);
-        assertEq(Maths.sqrt(Maths.wad(100)) * 10**9, 10 * 1e18);
-        assertEq(Maths.sqrt(Maths.wad(25)) * 10**9, 5 * 1e18);
-        assertEq(Maths.sqrt(11_000.143012091382543917 * 1e18) * 10**9, 104.881566598000000000 * 1e18);
-        assertEq(Maths.sqrt(100), 10);
+        assertEq(Maths.wsqrt(Maths.wad(100)), 10 * 1e18);
+        assertEq(Maths.wsqrt(Maths.wad(25)), 5 * 1e18);
+        assertEq(Maths.wsqrt(11_000.143012091382543917 * 1e18), 104.881566598000000000 * 1e18);
     }
 
 }

--- a/test/StandardFunding.t.sol
+++ b/test/StandardFunding.t.sol
@@ -182,6 +182,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertEq(votingPower, 0);
         votingPower = _getFundingVotes(_grantFund, _tokenHolder1);
         assertEq(votingPower, 2_500_000_000_000_000 * 1e18);
+        assertEq(_grantFund.getFundingPowerVotes(2_500_000_000_000_000 * 1e18), 50_000_000 * 1e18);
 
         // incremental votes that will be added to proposals accumulator is the sqrt of the voter's voting power
         _fundingVote(_grantFund, _tokenHolder1, proposal.proposalId, voteYes, 25_000_000 * 1e18);
@@ -189,11 +190,13 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         // voting power reduced when voted in funding stage
         votingPower = _getFundingVotes(_grantFund, _tokenHolder1);
         assertEq(votingPower, 1_875_000_000_000_000 * 1e18);
+        assertEq(_grantFund.getFundingPowerVotes(625_000_000_000_000 * 1e18), 25_000_000 * 1e18);
 
         // check that additional votes on the same proposal will calculate an accumulated square
         _fundingVote(_grantFund, _tokenHolder1, proposal.proposalId, voteYes, 10_000_000 * 1e18);
         votingPower = _getFundingVotes(_grantFund, _tokenHolder1);
         assertEq(votingPower, 1_275_000_000_000_000 * 1e18);
+        assertEq(_grantFund.getFundingPowerVotes(1_225_000_000_000_000 * 1e18), 35_000_000 * 1e18);
 
         // check revert if additional votes exceed the budget
         vm.expectRevert(IStandardFunding.InsufficientBudget.selector);
@@ -677,6 +680,8 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertEq(votingPowerRemaining, 475_000_000_000_000 * 1e18);
         assertEq(uint256(votingPowerRemaining), _grantFund.getVotesWithParams(_tokenHolder5, block.number, bytes("Funding")));
         assertEq(votesCast, 1);
+
+        assertEq(_grantFund.getFundingPowerVotes(2_500_000_000_000_000 * 1e18), 50_000_000 * 1e18);
 
         uint256[] memory potentialProposalSlate = new uint256[](2);
         potentialProposalSlate[0] = screenedProposals[0].proposalId;

--- a/test/StandardFunding.t.sol
+++ b/test/StandardFunding.t.sol
@@ -385,7 +385,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         uint256 votingPower = _getFundingVotes(_grantFund, _tokenHolder1);
 
         // voter allocates all of their voting power in support of the proposal
-        _fundingVote(_grantFund, _tokenHolder1, testProposals[1].proposalId, voteYes, int256(votingPower));
+        _fundingVote(_grantFund, _tokenHolder1, testProposals[1].proposalId, voteYes, 50_000_000 * 1e18);
         // check if user vote is updated after voting in funding stage 
         hasVoted = _grantFund.hasVoted(testProposals[1].proposalId, _tokenHolder1);
         assertTrue(hasVoted);

--- a/test/StandardFunding.t.sol
+++ b/test/StandardFunding.t.sol
@@ -1207,10 +1207,8 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
 
         // claim delegate reward for each voter
         for(uint i = 0; i < noOfVoters; i++) {
-            uint256 budgetAllocated = Maths.wpow(votes[i], 2);
-
             // calculate delegate reward for each voter
-            uint256 reward = Maths.wdiv(Maths.wmul(gbc, budgetAllocated), totalBudgetAllocated) / 10; 
+            uint256 reward = Maths.wdiv(Maths.wmul(gbc, votes[i]), totalBudgetAllocated) / 10;
             totalDelegationReward += reward; 
 
             // check whether reward calculated is correct

--- a/test/StandardFunding.t.sol
+++ b/test/StandardFunding.t.sol
@@ -386,9 +386,6 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         hasVoted = _grantFund.hasVoted(testProposals[1].proposalId, _tokenHolder1);
         assertFalse(hasVoted);
 
-        // get voting power in funding stage
-        uint256 votingPower = _getFundingVotes(_grantFund, _tokenHolder1);
-
         // voter allocates all of their voting power in support of the proposal
         _fundingVote(_grantFund, _tokenHolder1, testProposals[1].proposalId, voteYes, 50_000_000 * 1e18);
         // check if user vote is updated after voting in funding stage 
@@ -646,11 +643,16 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
 
         changePrank(_tokenHolder5);
         vm.expectRevert(IStandardFunding.InsufficientBudget.selector);
-        _grantFund.castVoteWithReasonAndParams(screenedProposals[3].proposalId, 0, "", abi.encode(-2_600_000_000_000_000 * 1e18));
+        _grantFund.castVoteWithReasonAndParams(screenedProposals[3].proposalId, voteNo, "", abi.encode(-2_600_000_000_000_000 * 1e18));
 
-        // check tokerHolder partial vote budget calculations
+        // check tokenHolder5 partial vote budget calculations
         _fundingVote(_grantFund, _tokenHolder5, screenedProposals[5].proposalId, voteNo, -45_000_000 * 1e18);
         screenedProposals = _getProposalListFromProposalIds(_grantFund, _grantFund.getTopTenProposals(distributionId));
+
+        // should revert if tokenHolder5 attempts to change the direction of a vote
+        changePrank(_tokenHolder5);
+        vm.expectRevert(IStandardFunding.FundingVoteInvalid.selector);
+        _grantFund.castVoteWithReasonAndParams(screenedProposals[5].proposalId, voteYes, "", abi.encode(5_000_000 * 1e18));
 
         // check remaining votes available to the above token holders
         (uint256 voterPower, uint256 votingPowerRemaining, uint256 votesCast) = _grantFund.getVoterInfo(distributionId, _tokenHolder1);

--- a/test/StandardFunding.t.sol
+++ b/test/StandardFunding.t.sol
@@ -199,7 +199,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertEq(_grantFund.getFundingPowerVotes(1_225_000_000_000_000 * 1e18), 35_000_000 * 1e18);
 
         // check revert if additional votes exceed the budget
-        vm.expectRevert(IStandardFunding.InsufficientBudget.selector);
+        vm.expectRevert(IStandardFunding.InsufficientVotingPower.selector);
         _grantFund.castVoteWithReasonAndParams(proposal.proposalId, 1, "", abi.encode(16_000_000 * 1e18));
     }
 
@@ -514,7 +514,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
      *  @dev    Maximum quarterly distribution is 10_000_000.
      *  @dev    Funded slate is executed.
      *  @dev    Reverts:
-     *              - IStandardFunding.InsufficientBudget
+     *              - IStandardFunding.InsufficientVotingPower
      *              - IStandardFunding.ExecuteProposalInvalid
      *              - "Governor: proposal not successful"
      */
@@ -629,7 +629,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
             votesUsed: -40_000_000 * 1e18
         });
         changePrank(_tokenHolder4);
-        vm.expectRevert(IStandardFunding.InsufficientBudget.selector);
+        vm.expectRevert(IStandardFunding.InsufficientVotingPower.selector);
         _grantFund.fundingVotesMulti(fundingVoteParams);
 
         // tokenholder4 divides their full votingpower into two proposals in one transaction
@@ -645,7 +645,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         screenedProposals = _getProposalListFromProposalIds(_grantFund, _grantFund.getTopTenProposals(distributionId));
 
         changePrank(_tokenHolder5);
-        vm.expectRevert(IStandardFunding.InsufficientBudget.selector);
+        vm.expectRevert(IStandardFunding.InsufficientVotingPower.selector);
         _grantFund.castVoteWithReasonAndParams(screenedProposals[3].proposalId, voteNo, "", abi.encode(-2_600_000_000_000_000 * 1e18));
 
         // check tokenHolder5 partial vote budget calculations

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -320,11 +320,8 @@ abstract contract GrantFundTestHelper is Test {
         votes = grantFund_.getVotesWithParams(voter_, block.number, bytes("Screening"));
     }
 
-    function _getFundingVotes(GrantFund grantFund_, address voter_) internal returns (uint256 votes) {
+    function _getFundingVotes(GrantFund grantFund_, address voter_) internal view returns (uint256 votes) {
         votes = grantFund_.getVotesWithParams(voter_, block.number, bytes("Funding"));
-        // emit log_uint(grantFund_.getDistributionId());
-        // (votes, , ) = grantFund_.getVoterInfo(grantFund_.getDistributionId(), voter_);
-
     }
 
     // TODO: rename this method

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -7,6 +7,7 @@ import { Test }     from "@std/Test.sol";
 
 import { GrantFund }        from "../../src/grants/GrantFund.sol";
 import { IStandardFunding } from "../../src/grants/interfaces/IStandardFunding.sol";
+import { Maths }           from "../../src/grants/libraries/Maths.sol";
 
 import { IAjnaToken }       from "./IAjnaToken.sol";
 
@@ -287,6 +288,16 @@ abstract contract GrantFundTestHelper is Test {
         vm.expectEmit(true, true, false, true);
         emit VoteCast(voter_, proposalId_, support_, voteAllocatedEmit, "");
         grantFund_.castVoteWithReasonAndParams(proposalId_, support_, reason, params);
+    }
+
+    function _fundingVoteMulti(GrantFund grantFund_, IStandardFunding.FundingVoteParams[] memory voteParams_, address voter_) internal {
+        for (uint256 i = 0; i < voteParams_.length; ++i) {
+            uint8 support = voteParams_[i].votesUsed < 0 ? 0 : 1;
+            vm.expectEmit(true, true, false, true);
+            emit VoteCast(voter_, voteParams_[i].proposalId, support, uint256(Maths.abs(voteParams_[i].votesUsed)), "");
+        }
+        changePrank(voter_);
+        grantFund_.fundingVotesMulti(voteParams_);
     }
 
     // Returns a random proposal Index from all proposals

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -309,8 +309,11 @@ abstract contract GrantFundTestHelper is Test {
         votes = grantFund_.getVotesWithParams(voter_, block.number, bytes("Screening"));
     }
 
-    function _getFundingVotes(GrantFund grantFund_, address voter_) internal view returns (uint256 votes) {
+    function _getFundingVotes(GrantFund grantFund_, address voter_) internal returns (uint256 votes) {
         votes = grantFund_.getVotesWithParams(voter_, block.number, bytes("Funding"));
+        // emit log_uint(grantFund_.getDistributionId());
+        // (votes, , ) = grantFund_.getVoterInfo(grantFund_.getDistributionId(), voter_);
+
     }
 
     // TODO: rename this method

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -305,6 +305,15 @@ abstract contract GrantFundTestHelper is Test {
         return voters_;
     }
 
+    function _getScreeningVotes(GrantFund grantFund_, address voter_) internal view returns (uint256 votes) {
+        votes = grantFund_.getVotesWithParams(voter_, block.number, bytes("Screening"));
+    }
+
+    function _getFundingVotes(GrantFund grantFund_, address voter_) internal view returns (uint256 votes) {
+        votes = grantFund_.getVotesWithParams(voter_, block.number, bytes("Funding"));
+    }
+
+    // TODO: rename this method
     // Transfers a random amount of tokens to N voters and self delegates votes
     function _getVotes(uint256 noOfVoters_, address[] memory voters_, IAjnaToken token_, address tokenDeployer_) internal returns(uint256[] memory) {
         uint256[] memory votes_ = new uint256[](noOfVoters_);
@@ -356,7 +365,7 @@ abstract contract GrantFundTestHelper is Test {
                 proposals[i].distributionId,
                 proposals[i].votesReceived,
                 proposals[i].tokensRequested,
-                proposals[i].qvBudgetAllocated,
+                proposals[i].fundingVotesReceived,
                 proposals[i].executed
             ) = grantFund_.getProposalInfo(proposalIds_[i]);
         }


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level

- Add `fundingVoteMulti` function to enable multiple funding votes to be cast in a single transaction.
- Add `FundingVoteParams` to track funding votes.
- Add `getFundingPowerVotes` which takes the sqrt of voting power to determine available discrete votes.
- split out delegate reward calculations and add `getDelegateRewards` external method to retrieve the delegate rewards available to a voter.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Fix the funding stage voting process to use the sum of the squares of votes cast as highlighted in: https://github.com/sherlock-audit/2023-01-ajna-judging/issues/64

Regarding grant coordination voting of the funding stage, the technical spec states (page24):

Each address that holds Ajna tokens can vote as much as they want on every proposal, including negative votes, subject to the constraint that the sum of the squares of their votes cannot exceed the square of the number of Ajna tokens held.

The code enforces that the sum of all votes of a user (in absolute value) is lower or equal than the square of its token holdings. The votes are not squared before being summed.
Impact

This leads to a higher centralization/control risk than should be. Alice can deploy a smart contract that proposes a funding of all the available tokens for that round towards itself. The contract can reward people delegating to it in case of a successful funding.

Due to the incorrect tally, if 100 token holders each have 1 token, Alice only needs to convince 10 of them to join her cause to successfully gain the funds. She would receive 10^2 = 100 votes, while all other voters could only produce 90 * 1^2 = 90 votes.

If the technical spec were respected and with the same token distribution of 100 tokens split among 100 holders, Alice would need to bribe 50 token holders to join her cause to gain the funding. She has 50^2 voting power and can vote once with50 while all other can vote 50 * 1^2 = 50.

I consider this difference significant enough to be considered medium severity.

# Gas usage
## Pre Change
<PASTE_OUTPUT_HERE>
## Post Change
```
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |
|---------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                             | Deployment Size |        |        |        |         |
| Function Name                               | min             | avg    | median | max    | # calls |
| castVote                                    | 8223            | 86975  | 94747  | 111920 | 40      |
| castVoteWithReasonAndParams                 | 4758            | 116932 | 125977 | 166871 | 17      |
| checkSlate                                  | 908             | 51254  | 70256  | 148508 | 16      |
| claimDelegateReward                         | 1596            | 42208  | 58975  | 65775  | 13      |
| fundingVotesMulti                           | 159359          | 231516 | 174144 | 495660 | 6       |
```