### PR TITLE
ToB GH issue #55

### DIFF
--- a/src/grants/interfaces/IExtraordinaryFunding.sol
+++ b/src/grants/interfaces/IExtraordinaryFunding.sol
@@ -82,12 +82,10 @@ interface IExtraordinaryFunding {
      * @notice Vote on a proposal for extraordinary funding.
      * @dev    Votes can only be cast affirmatively, or not cast at all.
      * @dev    A proposal can only be voted upon once, with the entirety of a voter's voting power.
-     * @param  account_    The voting account.
      * @param  proposalId_ The ID of the proposal being voted upon.
      * @return votesCast_  The amount of votes cast.
      */
     function voteExtraordinary(
-        address account_,
         uint256 proposalId_
     ) external returns (uint256 votesCast_);
 

--- a/test/ExtraordinaryFunding.t.sol
+++ b/test/ExtraordinaryFunding.t.sol
@@ -6,8 +6,9 @@ import { IVotes }    from "@oz/governance/utils/IVotes.sol";
 import { GrantFund }             from "../src/grants/GrantFund.sol";
 import { IExtraordinaryFunding } from "../src/grants/interfaces/IExtraordinaryFunding.sol";
 import { IFunding }              from "../src/grants/interfaces/IFunding.sol";
-import { GrantFundTestHelper } from "./utils/GrantFundTestHelper.sol";
-import { IAjnaToken }          from "./utils/IAjnaToken.sol";
+import { GrantFundTestHelper }   from "./utils/GrantFundTestHelper.sol";
+import { IAjnaToken }            from "./utils/IAjnaToken.sol";
+import { DrainGrantFund }        from "./interactions/DrainGrantFund.sol";
 
 contract ExtraordinaryFundingGrantFundTest is GrantFundTestHelper {
 
@@ -410,7 +411,7 @@ contract ExtraordinaryFundingGrantFundTest is GrantFundTestHelper {
 
         // should revert if user tries to vote again
         vm.expectRevert(IFunding.AlreadyVoted.selector);
-        _grantFund.voteExtraordinary(_tokenHolder1, testProposal.proposalId);
+        _grantFund.voteExtraordinary(testProposal.proposalId);
 
         // available votes should be 0 after voting
         uint256 availableVotes = _grantFund.getVotesExtraordinary(_tokenHolder1, testProposal.proposalId);
@@ -477,7 +478,7 @@ contract ExtraordinaryFundingGrantFundTest is GrantFundTestHelper {
 
         // Should revert if user tries to vote after proposal's end block
         vm.expectRevert(IExtraordinaryFunding.ExtraordinaryFundingProposalInactive.selector);
-        _grantFund.voteExtraordinary(_tokenHolder24, proposalId);
+        _grantFund.voteExtraordinary(proposalId);
 
         // check state is succeeded as expected
         proposalState = _grantFund.state(testProposal.proposalId);
@@ -650,6 +651,33 @@ contract ExtraordinaryFundingGrantFundTest is GrantFundTestHelper {
             }
         }
         
+    }
+
+    function testDrainTreasuryThroughExtraordinaryProposal() external {
+        // 24 tokenholders self delegate their tokens to enable voting on the proposals
+        _selfDelegateVoters(_token, _votersArr);
+        vm.roll(_startBlock + 33);
+
+        // the attacker's account
+        address attacker = makeAddr("attacker");
+        // add some ETH to attacker's account
+        vm.deal(attacker, 1e18);
+
+        changePrank(attacker);
+
+        // attacker Ajna balance is 0
+        assertEq(_token.balanceOf(attacker), 0);
+
+        // attacker should be able to vote only once on proposal
+        vm.expectRevert(IFunding.AlreadyVoted.selector);
+        new DrainGrantFund(
+            address(_token),
+            _grantFund,
+            _votersArr
+        );
+
+        // attacker Ajna balance should remain 0
+        assertEq(_token.balanceOf(attacker), 0);
     }
 
 }

--- a/test/interactions/DrainGrantFund.sol
+++ b/test/interactions/DrainGrantFund.sol
@@ -1,0 +1,43 @@
+pragma solidity 0.8.16;
+
+import { IExtraordinaryFunding } from "src/grants/interfaces/IExtraordinaryFunding.sol";
+import { IAjnaToken }            from "../utils/IAjnaToken.sol";
+
+contract DrainGrantFund {
+    constructor(
+        address ajnaToken,
+        IExtraordinaryFunding grantFund,
+        address[] memory tokenHolders // list of token holders that have voting power
+    ) {
+        // generate proposal targets
+        address[] memory targets = new address[](1);
+        targets[0] = ajnaToken;
+
+        // generate proposal values
+        uint256[] memory values = new uint256[](1);
+        values[0] = 0;
+
+        // generate proposal calldata, attacker wants to transfer 200 million Ajna to herself
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "transfer(address,uint256)",
+            msg.sender, // transfer ajna to this contract's deployer
+            250_000_000 * 1e18
+        );
+
+        uint endBlock = block.number + 100_000;
+
+        string memory description = "Extraordinary Proposal by attacker";
+
+        // attacker creates and submits her proposal
+        uint256 proposalId = grantFund.proposeExtraordinary(endBlock, targets, values, calldatas, description);
+
+        // attacker is going to make every token holder vote in favor of her proposal
+        for (uint i = 0; i < tokenHolders.length; i++) {
+            grantFund.voteExtraordinary(proposalId);
+        }
+
+        // execute the proposal, transferring the ajna to the attacker (this contract's deployer)
+        grantFund.executeExtraordinary(targets, values, calldatas, keccak256(bytes(description)));
+    }
+}

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -268,7 +268,7 @@ abstract contract GrantFundTestHelper is Test {
         changePrank(voter_);
         vm.expectEmit(true, true, false, true);
         emit VoteCast(voter_, proposalId_, support_, votingWeight, "");
-        grantFund_.voteExtraordinary(voter_, proposalId_);
+        grantFund_.voteExtraordinary(proposalId_);
     }
 
     function _fundingVote(GrantFund grantFund_, address voter_, uint256 proposalId_, uint8 support_, int256 votesAllocated_) internal {


### PR DESCRIPTION
- Attacker can use Extraordinary proposal to steal extraordinary amounts of Ajna
- remove `address account_` param of `voteExtraordinary` function, use `msg.sender` instead
- remove `_extraordinaryFundingVote` internal function, logic inline in `voteExtraordinary` function
- add attack test, assert that attacker cannot vote multiple times / on behalf of other addresses
- update unit tests