### PR TITLE
ToB Issue #58

### DIFF
--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -717,13 +717,13 @@ abstract contract StandardFunding is Funding, IStandardFunding {
             currentTopTenProposals.push(proposalId);
 
             // sort top ten proposals
-            _insertionSortProposalsByVotes(currentTopTenProposals);
+            _insertionSortProposalsByVotes(currentTopTenProposals, currentTopTenProposals.length - 1);
         }
         else {
             // proposal is already in the array
             if (indexInArray != -1) {
                 // re-sort top ten proposals to account for new vote totals
-                _insertionSortProposalsByVotes(currentTopTenProposals);
+                _insertionSortProposalsByVotes(currentTopTenProposals, uint256(indexInArray));
             }
             // proposal isn't already in the array
             else if(_standardFundingProposals[currentTopTenProposals[screenedProposalsLength - 1]].votesReceived < proposal_.votesReceived) {
@@ -732,7 +732,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
                 currentTopTenProposals.push(proposalId);
 
                 // sort top ten proposals
-                _insertionSortProposalsByVotes(currentTopTenProposals);
+                _insertionSortProposalsByVotes(currentTopTenProposals, 9);
             }
         }
 
@@ -807,27 +807,25 @@ abstract contract StandardFunding is Funding, IStandardFunding {
      * @dev    Implements the descending insertion sort algorithm.
      * @dev    Counters incremented in an unchecked block due to being bounded by array length.
      * @dev    Since we are converting from int256 to uint256, we can safely assume that the values will not overflow.
-     * @param arr_ The array of proposals to sort by votes received.
+     * @param proposals_        The array of proposals to sort by votes received.
+     * @param targetProposalId_ The targeted proposal id to insert.
      */
     function _insertionSortProposalsByVotes(
-        uint256[] storage arr_
+        uint256[] storage proposals_,
+        uint256 targetProposalId_
     ) internal {
-        int256 arrayLength = int256(arr_.length);
+        while (
+            targetProposalId_ != 0
+            &&
+            _standardFundingProposals[proposals_[targetProposalId_]].votesReceived > _standardFundingProposals[proposals_[targetProposalId_ - 1]].votesReceived
+        ) {
+            // swap values if left item < right item
+            uint256 temp = proposals_[targetProposalId_ - 1];
 
-        for (int i = 1; i < arrayLength;) {
-            Proposal memory key = _standardFundingProposals[arr_[uint(i)]];
-            int j = i;
+            proposals_[targetProposalId_ - 1] = proposals_[targetProposalId_];
+            proposals_[targetProposalId_] = temp;
 
-            while (j > 0 && key.votesReceived > _standardFundingProposals[arr_[uint(j - 1)]].votesReceived) {
-                // swap values if left item < right item
-                uint256 temp = arr_[uint(j - 1)];
-                arr_[uint(j - 1)] = arr_[uint(j)];
-                arr_[uint(j)] = temp;
-
-                unchecked { --j; }
-            }
-
-            unchecked { ++i; }
+            unchecked { --targetProposalId_; }
         }
     }
 

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -717,7 +717,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
             currentTopTenProposals.push(proposalId);
 
             // sort top ten proposals
-            _insertionSortProposalsByVotes(currentTopTenProposals, currentTopTenProposals.length - 1);
+            _insertionSortProposalsByVotes(currentTopTenProposals, screenedProposalsLength);
         }
         else {
             // proposal is already in the array
@@ -732,7 +732,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
                 currentTopTenProposals.push(proposalId);
 
                 // sort top ten proposals
-                _insertionSortProposalsByVotes(currentTopTenProposals, currentTopTenProposals.length - 1);
+                _insertionSortProposalsByVotes(currentTopTenProposals, screenedProposalsLength - 1);
             }
         }
 

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -732,7 +732,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
                 currentTopTenProposals.push(proposalId);
 
                 // sort top ten proposals
-                _insertionSortProposalsByVotes(currentTopTenProposals, 9);
+                _insertionSortProposalsByVotes(currentTopTenProposals, currentTopTenProposals.length - 1);
             }
         }
 


### PR DESCRIPTION
- gas optimization: call _insertionSortProposalsByVotes with an extra argument targetProposalIdx and get rid of the outer loop
- better naming of _insertionSortProposalsByVotes parameters

Gas after
```
| Function Name                               | min             | avg    | median | max    | # calls |
| claimDelegateReward                         | 1407            | 58045  | 58540  | 65340  | 443     |
| executeExtraordinary                        | 7152            | 44007  | 12854  | 95588  | 5       |
| executeStandard                             | 8775            | 29860  | 37905  | 47659  | 8       |
| findMechanismOfProposal                     | 613             | 2043   | 799    | 4719   | 3       |
| fundTreasury                                | 8001            | 45104  | 44641  | 65872  | 29      |
| fundingVote                                 | 1584            | 106415 | 106318 | 409345 | 458     |
| getDelegateReward                           | 2975            | 3465   | 2975   | 5017   | 5       |
| getDistributionId                           | 374             | 403    | 374    | 2374   | 1023    |
| getDistributionPeriodInfo                   | 1046            | 1735   | 1046   | 5046   | 87      |
| getExtraordinaryProposalInfo                | 992             | 992    | 992    | 992    | 3       |
| getExtraordinaryProposalSucceeded           | 2245            | 2664   | 2740   | 3008   | 3       |
| getFundedProposalSlate                      | 1133            | 1309   | 1368   | 1368   | 4       |
| getFundingPowerVotes                        | 15500           | 15688  | 15751  | 15751  | 4       |
| getFundingVotesCast                         | 1577            | 2317   | 2317   | 3057   | 2       |
| getMinimumThresholdPercentage               | 471             | 1227   | 739    | 2471   | 3       |
| getProposalInfo                             | 980             | 980    | 980    | 980    | 110     |
| getSlateHash                                | 872             | 880    | 884    | 884    | 3       |
| getSliceOfNonTreasury                       | 1577            | 4827   | 4827   | 8077   | 2       |
| getSliceOfTreasury                          | 781             | 1781   | 1781   | 2781   | 2       |
| getTopTenProposals                          | 1187            | 2451   | 2363   | 3304   | 16      |
| getVoterInfo                                | 1002            | 1002   | 1002   | 1002   | 5       |
| getVotesExtraordinary                       | 764             | 7451   | 7600   | 8755   | 58      |
| getVotesFunding                             | 2389            | 6565   | 2797   | 11518  | 15      |
| getVotesScreening                           | 5313            | 5351   | 5347   | 6489   | 901     |
| hasVotedExtraordinary                       | 683             | 1683   | 1683   | 2683   | 2       |
| hashProposal                                | 3843            | 3843   | 3843   | 3843   | 80      |
| proposeExtraordinary                        | 4497            | 53642  | 86095  | 86265  | 12      |
| proposeStandard                             | 4475            | 78270  | 82321  | 82660  | 82      |
| screeningVote                               | 1847            | 43170  | 37690  | 401046 | 477     |
| screeningVotesCast                          | 663             | 1329   | 663    | 2663   | 3       |
| startNewDistributionPeriod                  | 617             | 48521  | 53163  | 75597  | 20      |
| state                                       | 1337            | 4038   | 3344   | 7331   | 15      |
| updateSlate                                 | 971             | 56593  | 69994  | 289784 | 17      |
| voteExtraordinary                           | 565             | 27886  | 29377  | 31424  | 55      |
```

Gas before
```
| Function Name                               | min             | avg    | median | max    | # calls |
| claimDelegateReward                         | 1407            | 58037  | 58540  | 65340  | 436     |
| executeExtraordinary                        | 7152            | 42738  | 39567  | 95588  | 7       |
| executeStandard                             | 8775            | 29860  | 37905  | 47659  | 8       |
| findMechanismOfProposal                     | 613             | 2043   | 799    | 4719   | 3       |
| fundTreasury                                | 8001            | 45104  | 44641  | 65872  | 29      |
| fundingVote                                 | 1584            | 106417 | 106376 | 409345 | 451     |
| getDelegateReward                           | 2975            | 3465   | 2975   | 5017   | 5       |
| getDistributionId                           | 374             | 404    | 374    | 2374   | 995     |
| getDistributionPeriodInfo                   | 1046            | 1867   | 1046   | 5046   | 73      |
| getExtraordinaryProposalInfo                | 992             | 992    | 992    | 992    | 3       |
| getExtraordinaryProposalSucceeded           | 2245            | 2664   | 2740   | 3008   | 3       |
| getFundedProposalSlate                      | 1133            | 1309   | 1368   | 1368   | 4       |
| getFundingPowerVotes                        | 15500           | 15688  | 15751  | 15751  | 4       |
| getFundingVotesCast                         | 1577            | 2317   | 2317   | 3057   | 2       |
| getMinimumThresholdPercentage               | 471             | 1227   | 739    | 2471   | 3       |
| getProposalInfo                             | 980             | 980    | 980    | 980    | 110     |
| getSlateHash                                | 872             | 880    | 884    | 884    | 3       |
| getSliceOfNonTreasury                       | 1577            | 4827   | 4827   | 8077   | 2       |
| getSliceOfTreasury                          | 781             | 1781   | 1781   | 2781   | 2       |
| getTopTenProposals                          | 1187            | 2451   | 2363   | 3304   | 16      |
| getVoterInfo                                | 1002            | 1002   | 1002   | 1002   | 5       |
| getVotesExtraordinary                       | 764             | 7644   | 7681   | 8755   | 363     |
| getVotesFunding                             | 2389            | 6565   | 2797   | 11518  | 15      |
| getVotesScreening                           | 5313            | 5351   | 5347   | 6489   | 887     |
| hasVotedExtraordinary                       | 683             | 1683   | 1683   | 2683   | 2       |
| hashProposal                                | 3843            | 3843   | 3843   | 3843   | 68      |
| proposeExtraordinary                        | 4497            | 57683  | 83926  | 86265  | 14      |
| proposeStandard                             | 4475            | 77505  | 82660  | 82660  | 68      |
| screeningVote                               | 1847            | 53908  | 52443  | 466426 | 470     |
| screeningVotesCast                          | 663             | 1329   | 663    | 2663   | 3       |
| startNewDistributionPeriod                  | 617             | 48521  | 53163  | 75597  | 20      |
| state                                       | 1337            | 4271   | 3838   | 7331   | 17      |
| updateSlate                                 | 971             | 56593  | 69994  | 289784 | 17      |
| voteExtraordinary                           | 565             | 29217  | 29458  | 31424  | 360     |
```