### PR TITLE
Revert Ajna token code to deployed version

### DIFF
--- a/src/token/AjnaToken.sol
+++ b/src/token/AjnaToken.sol
@@ -40,10 +40,12 @@ contract AjnaToken is ERC20, ERC20Burnable, ERC20Permit, ERC20Votes {
     /*** External Functions ***/
     /**************************/
 
+
     /**
      *  @notice Called by an owner of AJNA tokens to enable their tokens to be transferred by a spender address without making a seperate permit call
      *  @param  from_     The address of the current owner of the tokens
      *  @param  to_       The address of the new owner of the tokens
+     *  @param  spender_  The address of the third party who will execute the transaction involving an owners tokens
      *  @param  value_    The amount of tokens to transfer
      *  @param  deadline_ The unix timestamp by which the permit must be called
      *  @param  v_        Component of secp256k1 signature
@@ -51,9 +53,9 @@ contract AjnaToken is ERC20, ERC20Burnable, ERC20Permit, ERC20Votes {
      *  @param  s_        Component of secp256k1 signature
      */
     function transferFromWithPermit(
-        address from_, address to_, uint256 value_, uint256 deadline_, uint8 v_, bytes32 r_, bytes32 s_
+        address from_, address to_, address spender_, uint256 value_, uint256 deadline_, uint8 v_, bytes32 r_, bytes32 s_
     ) external {
-        permit(from_, msg.sender, value_, deadline_, v_, r_, s_);
+        permit(from_, spender_, value_, deadline_, v_, r_, s_);
         transferFrom(from_, to_, value_);
     }
 }

--- a/test/AjnaToken.t.sol
+++ b/test/AjnaToken.t.sol
@@ -133,7 +133,7 @@ contract AjnaTokenTest is Test {
         digest = _sigUtils.getTypedDataHash(permit);
         (v, r, s) = vm.sign(ownerPrivateKey, digest);
 
-        _token.transferFromWithPermit(owner, newOwner, amount_, permit.deadline, v, r, s);
+        _token.transferFromWithPermit(owner, newOwner, spender, amount_, permit.deadline, v, r, s);
         // check owner and spender balances after 2nd transfer with permit
         assertEq(_token.balanceOf(owner),    0);
         assertEq(_token.balanceOf(spender),  0);
@@ -153,7 +153,7 @@ contract AjnaTokenTest is Test {
         (v, r, s) = vm.sign(ownerPrivateKey, digest);
 
         vm.expectRevert("ERC20: transfer amount exceeds balance");
-        _token.transferFromWithPermit(owner, newOwner, 1, permit.deadline, v, r, s);
+        _token.transferFromWithPermit(owner, newOwner, spender, 1, permit.deadline, v, r, s);
     }
 
     /*********************/


### PR DESCRIPTION
This reverts the token code to match that of the currently deployed Ajna token on mainnet. 

This can be verified by comparing with the relevant commit: https://github.com/ajna-finance/ecosystem-coordination/blob/15b818a4a9eebf722b2c35760cea998afa095569/src/BaseToken.sol