### PR TITLE
TOB-AJNA-7: Prevent collision of proposalIds in standard and extraordinary funding

### DIFF
--- a/src/grants/base/ExtraordinaryFunding.sol
+++ b/src/grants/base/ExtraordinaryFunding.sol
@@ -20,7 +20,7 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
     /**
      * @notice The maximum length of a proposal's voting period, in blocks.
      */
-    uint256 internal constant MAX_EFM_PROPOSAL_LENGTH                  = 216_000; // number of blocks in one month
+    uint256 internal constant MAX_EFM_PROPOSAL_LENGTH = 216_000; // number of blocks in one month
 
     /**
      * @notice Keccak hash of a prefix string for extraordinary funding mechanism

--- a/src/grants/base/ExtraordinaryFunding.sol
+++ b/src/grants/base/ExtraordinaryFunding.sol
@@ -54,7 +54,7 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
         bytes[] memory calldatas_,
         bytes32 descriptionHash_
     ) external nonReentrant override returns (uint256 proposalId_) {
-        proposalId_ = _hashProposal(targets_, values_, calldatas_, descriptionHash_);
+        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(keccak256(bytes("Extraordinary Funding: ")), descriptionHash_)));
 
         ExtraordinaryFundingProposal storage proposal = _extraordinaryFundingProposals[proposalId_];
 
@@ -84,7 +84,7 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
         bytes[] memory calldatas_,
         string memory description_) external override returns (uint256 proposalId_) {
 
-        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(bytes(description_)));
+        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(keccak256(bytes("Extraordinary Funding: ")), keccak256(bytes(description_)))));
 
         ExtraordinaryFundingProposal storage newProposal = _extraordinaryFundingProposals[proposalId_];
 

--- a/src/grants/base/ExtraordinaryFunding.sol
+++ b/src/grants/base/ExtraordinaryFunding.sol
@@ -20,7 +20,12 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
     /**
      * @notice The maximum length of a proposal's voting period, in blocks.
      */
-    uint256 internal constant MAX_EFM_PROPOSAL_LENGTH = 216_000; // number of blocks in one month
+    uint256 internal constant MAX_EFM_PROPOSAL_LENGTH                  = 216_000; // number of blocks in one month
+
+    /**
+     * @notice Keccak hash of a prefix string for extraordinary funding mechanism
+     */
+    bytes32 internal constant DESCRIPTION_PREFIX_HASH_EXTRAORDINARY = keccak256(bytes("Extraordinary Funding: "));
 
     /***********************/
     /*** State Variables ***/
@@ -54,7 +59,7 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
         bytes[] memory calldatas_,
         bytes32 descriptionHash_
     ) external nonReentrant override returns (uint256 proposalId_) {
-        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(keccak256(bytes("Extraordinary Funding: ")), descriptionHash_)));
+        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(DESCRIPTION_PREFIX_HASH_EXTRAORDINARY, descriptionHash_)));
 
         ExtraordinaryFundingProposal storage proposal = _extraordinaryFundingProposals[proposalId_];
 
@@ -84,7 +89,7 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
         bytes[] memory calldatas_,
         string memory description_) external override returns (uint256 proposalId_) {
 
-        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(keccak256(bytes("Extraordinary Funding: ")), keccak256(bytes(description_)))));
+        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(DESCRIPTION_PREFIX_HASH_EXTRAORDINARY, keccak256(bytes(description_)))));
 
         ExtraordinaryFundingProposal storage newProposal = _extraordinaryFundingProposals[proposalId_];
 

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -343,7 +343,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         bytes[] memory calldatas_,
         bytes32 descriptionHash_
     ) external nonReentrant override returns (uint256 proposalId_) {
-        proposalId_ = _hashProposal(targets_, values_, calldatas_, descriptionHash_);
+        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(keccak256(bytes("Standard Funding: ")), descriptionHash_)));
         Proposal storage proposal = _standardFundingProposals[proposalId_];
 
         uint24 distributionId = proposal.distributionId;
@@ -366,7 +366,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         bytes[] memory calldatas_,
         string memory description_
     ) external override returns (uint256 proposalId_) {
-        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(bytes(description_)));
+        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(keccak256(bytes("Standard Funding: ")), keccak256(bytes(description_)))));
 
         Proposal storage newProposal = _standardFundingProposals[proposalId_];
 

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -45,6 +45,11 @@ abstract contract StandardFunding is Funding, IStandardFunding {
      */
     uint256 internal constant FUNDING_PERIOD_LENGTH = 72000;
 
+    /**
+     * @notice Keccak hash of a prefix string for standard funding mechanism
+     */
+    bytes32 internal constant DESCRIPTION_PREFIX_HASH_STANDARD = keccak256(bytes("Standard Funding: "));
+
     /***********************/
     /*** State Variables ***/
     /***********************/
@@ -343,7 +348,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         bytes[] memory calldatas_,
         bytes32 descriptionHash_
     ) external nonReentrant override returns (uint256 proposalId_) {
-        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(keccak256(bytes("Standard Funding: ")), descriptionHash_)));
+        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(DESCRIPTION_PREFIX_HASH_STANDARD, descriptionHash_)));
         Proposal storage proposal = _standardFundingProposals[proposalId_];
 
         uint24 distributionId = proposal.distributionId;
@@ -366,7 +371,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         bytes[] memory calldatas_,
         string memory description_
     ) external override returns (uint256 proposalId_) {
-        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(keccak256(bytes("Standard Funding: ")), keccak256(bytes(description_)))));
+        proposalId_ = _hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(DESCRIPTION_PREFIX_HASH_STANDARD, keccak256(bytes(description_)))));
 
         Proposal storage newProposal = _standardFundingProposals[proposalId_];
 

--- a/test/StandardFunding.t.sol
+++ b/test/StandardFunding.t.sol
@@ -895,7 +895,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
 
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0x53dc2b0b8c3787b3384472e1d449bb35e20089a01306e21d59ec6d080cdcd1a8);
+        assertEq(slateHash, 0x55e999c21a3faf0bdde6c3dbdeb20311552e5ac9eb607c60f379172c78240156);
         // check funded proposal slate matches expected state
         GrantFund.Proposal[] memory fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 1);
@@ -911,7 +911,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertTrue(proposalSlateUpdated);
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0x1baa18a2d105ff81cc846882b7cc083ac252a82d2082db41156a83ae5d6a2436);
+        assertEq(slateHash, 0xb72e359fc43715be27ea92fd3c6675ddc7ebca9c2f6ac8b8f1a8195c0b579067);
         // check funded proposal slate matches expected state
         fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
@@ -935,7 +935,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertTrue(proposalSlateUpdated);
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0x6d2192bdd3e08d75d683185db5947cd199403513241eddfa5cf8a36256f27c40);
+        assertEq(slateHash, 0x59445eae0a1138f27e258b071c6210dbd8fec6d1d7da077f3586a8aaa89806ce);
         // check funded proposal slate matches expected state
         fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
@@ -951,7 +951,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
 
         // check funded proposal slate wasn't updated
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0x6d2192bdd3e08d75d683185db5947cd199403513241eddfa5cf8a36256f27c40);
+        assertEq(slateHash, 0x59445eae0a1138f27e258b071c6210dbd8fec6d1d7da077f3586a8aaa89806ce);
         fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
         assertEq(fundedProposalSlate[0].proposalId, screenedProposals[0].proposalId);

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -110,7 +110,7 @@ abstract contract GrantFundTestHelper is Test {
         string memory description
     ) internal returns (TestProposalExtraordinary memory) {
         // generate expected proposal state
-        uint256 expectedProposalId = grantFund_.hashProposal(targets_, values_, proposalCalldatas_, keccak256(bytes(description)));
+        uint256 expectedProposalId = grantFund_.hashProposal(targets_, values_, proposalCalldatas_, keccak256(abi.encode(keccak256(bytes("Extraordinary Funding: ")), keccak256(bytes(description)))));
         uint256 startBlock = block.number;
 
         // submit proposal
@@ -141,7 +141,7 @@ abstract contract GrantFundTestHelper is Test {
 
     function _createProposalStandard(GrantFund grantFund_, address proposer_, address[] memory targets_, uint256[] memory values_, bytes[] memory proposalCalldatas_, string memory description) internal returns (TestProposal memory) {
         // generate expected proposal state
-        uint256 expectedProposalId = grantFund_.hashProposal(targets_, values_, proposalCalldatas_, keccak256(bytes(description)));
+        uint256 expectedProposalId = grantFund_.hashProposal(targets_, values_, proposalCalldatas_, keccak256(abi.encode(keccak256(bytes("Standard Funding: ")), keccak256(bytes(description)))));
         uint256 startBlock = block.number.toUint64();
 
         (, , uint48 endBlock, , , ) = grantFund_.getDistributionPeriodInfo(grantFund_.getDistributionId());


### PR DESCRIPTION
* `ProposalId` collision for extraordinary and standard funding is prevented by hashing strings `Extraordinary Funding: ` and `Standard Funding: ` with description hash respectively

# Gas usage
## Pre Change
```| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |
|---------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                             | Deployment Size |        |        |        |         |
| 4657644                                     | 23260           |        |        |        |         |
| Function Name                               | min             | avg    | median | max    | # calls |
| claimDelegateReward                         | 1407            | 57405  | 58540  | 65340  | 193     |
| executeExtraordinary                        | 7152            | 42342  | 39567  | 95588  | 8       |
| executeStandard                             | 8775            | 29860  | 37905  | 47659  | 8       |
| findMechanismOfProposal                     | 613             | 2043   | 799    | 4719   | 3       |
| fundTreasury                                | 8001            | 45104  | 44641  | 65872  | 29      |
| fundingVote                                 | 1584            | 105607 | 105266 | 409345 | 208     |
| getDelegateReward                           | 2975            | 3465   | 2975   | 5017   | 5       |
| getDistributionId                           | 374             | 433    | 374    | 2374   | 502     |
| getDistributionPeriodInfo                   | 1046            | 1955   | 1046   | 5046   | 66      |
| getExtraordinaryProposalInfo                | 992             | 992    | 992    | 992    | 3       |
| getExtraordinaryProposalSucceeded           | 2245            | 2664   | 2740   | 3008   | 3       |
| getFundedProposalSlate                      | 1133            | 1309   | 1368   | 1368   | 4       |
| getFundingPowerVotes                        | 15500           | 15688  | 15751  | 15751  | 4       |
| getFundingVotesCast                         | 1577            | 2317   | 2317   | 3057   | 2       |
| getMinimumThresholdPercentage               | 471             | 1227   | 739    | 2471   | 3       |
| getProposalInfo                             | 980             | 980    | 980    | 980    | 105     |
| getSlateHash                                | 872             | 880    | 884    | 884    | 3       |
| getSliceOfNonTreasury                       | 1577            | 4827   | 4827   | 8077   | 2       |
| getSliceOfTreasury                          | 781             | 1781   | 1781   | 2781   | 2       |
| getTopTenProposals                          | 1187            | 2377   | 2363   | 3304   | 16      |
| getVoterInfo                                | 1002            | 1002   | 1002   | 1002   | 5       |
| getVotesExtraordinary                       | 764             | 7651   | 7681   | 8755   | 449     |
| getVotesFunding                             | 2389            | 6565   | 2797   | 11518  | 15      |
| getVotesScreening                           | 5313            | 5356   | 5347   | 6489   | 401     |
| hasVotedExtraordinary                       | 683             | 1683   | 1683   | 2683   | 2       |
| hashProposal                                | 3843            | 3843   | 3843   | 3843   | 62      |
| proposeExtraordinary                        | 4497            | 59299  | 81926  | 86265  | 15      |
| proposeStandard                             | 4475            | 76991  | 82660  | 82660  | 61      |
| screeningVote                               | 1847            | 42235  | 36714  | 399146 | 227     |
| screeningVotesCast                          | 663             | 1329   | 663    | 2663   | 3       |
| startNewDistributionPeriod                  | 617             | 48521  | 53163  | 75597  | 20      |
| state                                       | 1337            | 4369   | 3842   | 7331   | 18      |
| updateSlate                                 | 971             | 49813  | 69994  | 174519 | 17      |
| voteExtraordinary                           | 565             | 29264  | 29458  | 31424  | 446     |
```

## Post Change
```| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |
|---------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                             | Deployment Size |        |        |        |         |
| 4748368                                     | 23713           |        |        |        |         |
| Function Name                               | min             | avg    | median | max    | # calls |
| claimDelegateReward                         | 1407            | 57127  | 58540  | 65340  | 155     |
| executeExtraordinary                        | 7387            | 43502  | 26445  | 95823  | 6       |
| executeStandard                             | 9009            | 30094  | 38140  | 47894  | 8       |
| findMechanismOfProposal                     | 613             | 2043   | 799    | 4719   | 3       |
| fundTreasury                                | 8001            | 45104  | 44641  | 65872  | 29      |
| fundingVote                                 | 1584            | 105502 | 105113 | 409345 | 170     |
| getDelegateReward                           | 2975            | 3465   | 2975   | 5017   | 5       |
| getDistributionId                           | 374             | 444    | 374    | 2374   | 425     |
| getDistributionPeriodInfo                   | 1046            | 1969   | 1046   | 5046   | 65      |
| getExtraordinaryProposalInfo                | 992             | 992    | 992    | 992    | 3       |
| getExtraordinaryProposalSucceeded           | 2245            | 2664   | 2740   | 3008   | 3       |
| getFundedProposalSlate                      | 1133            | 1309   | 1368   | 1368   | 4       |
| getFundingPowerVotes                        | 15500           | 15688  | 15751  | 15751  | 4       |
| getFundingVotesCast                         | 1577            | 2317   | 2317   | 3057   | 2       |
| getMinimumThresholdPercentage               | 471             | 1227   | 739    | 2471   | 3       |
| getProposalInfo                             | 980             | 980    | 980    | 980    | 104     |
| getSlateHash                                | 872             | 880    | 884    | 884    | 3       |
| getSliceOfNonTreasury                       | 1577            | 4827   | 4827   | 8077   | 2       |
| getSliceOfTreasury                          | 781             | 1781   | 1781   | 2781   | 2       |
| getTopTenProposals                          | 1187            | 2363   | 2363   | 3304   | 16      |
| getVoterInfo                                | 1002            | 1002   | 1002   | 1002   | 5       |
| getVotesExtraordinary                       | 764             | 7531   | 7681   | 8755   | 89      |
| getVotesFunding                             | 2389            | 6565   | 2797   | 11518  | 15      |
| getVotesScreening                           | 5313            | 5359   | 5347   | 6489   | 325     |
| hasVotedExtraordinary                       | 683             | 1683   | 1683   | 2683   | 2       |
| hashProposal                                | 3843            | 3843   | 3843   | 3843   | 59      |
| proposeExtraordinary                        | 4731            | 56052  | 86161  | 86500  | 13      |
| proposeStandard                             | 4709            | 77143  | 82895  | 82895  | 60      |
| screeningVote                               | 1847            | 43022  | 36446  | 399146 | 189     |
| screeningVotesCast                          | 663             | 1329   | 663    | 2663   | 3       |
| startNewDistributionPeriod                  | 617             | 48521  | 53163  | 75597  | 20      |
| state                                       | 1337            | 4162   | 3591   | 7331   | 16      |
| updateSlate                                 | 971             | 48224  | 69994  | 147512 | 17      |
| voteExtraordinary                           | 565             | 28452  | 29458  | 31424  | 86      |

```