### PR TITLE
verify contracts, update README with funding instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ snapshot :; forge clean && forge snapshot --optimize --optimize-runs 1000000
 deploy-ajnatoken:
 	eval MINT_TO_ADDRESS=${mintto}
 	forge script script/AjnaToken.s.sol:DeployAjnaToken \
-		--rpc-url ${ETH_RPC_URL} --sender ${DEPLOY_ADDRESS} --keystore ${DEPLOY_KEY} --broadcast -vvv
+		--rpc-url ${ETH_RPC_URL} --sender ${DEPLOY_ADDRESS} --keystore ${DEPLOY_KEY} --broadcast -vvv --verify
 deploy-grantfund:
 	eval AJNA_TOKEN=${ajna}
 	forge script script/GrantFund.s.sol:DeployGrantFund \
-		--rpc-url ${ETH_RPC_URL} --sender ${DEPLOY_ADDRESS} --keystore ${DEPLOY_KEY} --broadcast -vvv
+		--rpc-url ${ETH_RPC_URL} --sender ${DEPLOY_ADDRESS} --keystore ${DEPLOY_KEY} --broadcast -vvv --verify

--- a/README.md
+++ b/README.md
@@ -74,20 +74,20 @@ If you wish to deploy against an `anvil` or `ganache` endpoint, edit the `Makefi
 
 
 #### AJNA token
-Deployment of the AJNA token requires an argument stating where minted tokens should be sent.  AJNA has already been deployed to Goerli and Mainnet; see [AJNA_TOKEN.md](src/token/AJNA_TOKEN.md#ajna-token) for addresses.  There is no reason to deploy the AJNA token to L2s or sidechains; see [MULTICHAIN_STRATEGY.md](MULTICHAIN_STRATEGY.md) for details.  Since contract verification only works on Etherscan-supported networks, the `--verify` switch has been omitted.  Upon deployment, minted tokens are transferred to a user-specified address which must be specified in make arguments.  To run a new deployment on a test network or local testchain, run:
+Deployment of the AJNA token requires an argument stating where minted tokens should be sent.  AJNA has already been deployed to Goerli and Mainnet; see [AJNA_TOKEN.md](src/token/AJNA_TOKEN.md#ajna-token) for addresses.  There is no reason to deploy the AJNA token to L2s or sidechains; see [MULTICHAIN_STRATEGY.md](MULTICHAIN_STRATEGY.md) for details.  Upon deployment, minted tokens are transferred to a user-specified address which must be specified in make arguments.  To run a new deployment on a test network or local testchain, run:
 ```
 make deploy-ajnatoken mintto=<MINT_TO_ADDRESS>
 ```
 Record the address of the token upon deployment.  See [AJNA_TOKEN.md](src/token/AJNA_TOKEN.md#deployment) for validation.
 
 #### Grant Fund
-Deployment of the Grant Coordination Fund requires no constructor arguments.
+Although the Grant Coordination Fund requires no constructor arguments, the deployment script uses the token address to determine funding level.
 
-Since contract source has not yet been made public, the `--verify` switch has been omitted.  To deploy, run:
-```
-make deploy-grantfund
-```
+Before deploying, edit `src/grants/base/Funding.sol` to set the correct AJNA token address for the target chain.
 
-The Grant Fund is by default deployed without any Ajna tokens in it's treasury. To add tokens, someone must call `fundTreasury()` with the amount of Ajna tokens to transfer to the Grant Fund. **WARNING**: Ajna tokens transferred directly to the treasury won't be credited to the treasury balance if `fundTreasury()` is circumvented.
+To deploy, run:
+```
+make deploy-grantfund ajna=<AJNA_TOKEN_ADDRESS>
+```
 
 See [GRANT_FUND.md](src/grants/GRANT_FUND.md#deployment) for next steps.

--- a/src/grants/GRANT_FUND.md
+++ b/src/grants/GRANT_FUND.md
@@ -5,7 +5,7 @@ As a decentralized protocol with no external governance, Ajna requires a sustain
 | Deployment | Address |
 | ---------: | ------- |
 | Mainnet    | (net yet deployed) |
-| Goerli     | [0xc9216387C7920C8a7b6C2cE4A44dEd5776a3B5B4](https://goerli.etherscan.io/address/0xc9216387C7920C8a7b6C2cE4A44dEd5776a3B5B4) |
+| Goerli     | [0x54110a15011bcb145a8CD4f5adf108B2B6939A1e](https://goerli.etherscan.io/address/0xc9216387C7920C8a7b6C2cE4A44dEd5776a3B5B4) |
 
 ## Design
 
@@ -74,15 +74,18 @@ See [README.md](../../README.md) for instructions using the `Makefile` target.
 Output should confirm the AJNA token address, provid the GrantFund address, and the amount of AJNA which should be transferred to the GrantFund adress:
 ```
 == Logs ==
-  Deploying GrantFund to chain with AJNA token address 0xaadebCF61AA7Da0573b524DE57c67aDa797D46c5
+  Deploying GrantFund to chain
   GrantFund deployed to 0xc9216387C7920C8a7b6C2cE4A44dEd5776a3B5B4
-  Please transfer 600000000 AJNA (600000000000000000000000000 WAD) into the treasury
+  Please transfer 300000000 AJNA (300000000000000000000000000 WAD) into the treasury
 ```
 
-Record the deployment address in your environment as `GRANTFUND_ADDRESS`.  As requested, transfer the specified amount of AJNA tokens to the GrantFund address.  WAD-scaled value was included in output for copy/paste convenience.
+Record the deployment address in your environment as `GRANTFUND_ADDRESS`.
+
+The Grant Fund is by default deployed without any Ajna tokens in it's treasury. To add tokens, someone must call `fundTreasury(uint256)` with the amount of Ajna tokens to transfer to the Grant Fund. **WARNING**: Ajna tokens transferred directly to the treasury won't be credited to the treasury balance if `fundTreasury` is circumvented.
 
 To perform the transfer, set `TREASURY_ADDRESS` and `TREASURY_KEY` to the appropriate values and run the following:
 
 ```
-cast send ${AJNA_TOKEN} "transfer(address,uint256)" ${GRANTFUND_ADDRESS} 600000000000000000000000000 --from ${TREASURY_ADDRESS} --keystore ${TREASURY_KEY} --rpc-url ${ETH_RPC_URL} 
+cast send ${AJNA_TOKEN} "approve(address,uint256)" ${GRANTFUND_ADDRESS} 300000000000000000000000000 --from ${TREASURY_ADDRESS} --keystore ${TREASURY_KEY} --rpc-url ${ETH_RPC_URL} 
+cast send ${GRANTFUND_ADDRESS} "fundTreasury(uint256)" 300000000000000000000000000 --from ${TREASURY_ADDRESS} --keystore ${TREASURY_KEY} --rpc-url ${ETH_RPC_URL} 
 ```


### PR DESCRIPTION
No source code changes, so PR template has been omitted.
Updated `Makefile` to verify contracts.
Updated README to explain why AJNA token address is (still) a required arg to the deployment script, even though it is not a ctor arg.  Documented transactions to fund the contract after deployment.