### PR TITLE
Forge 1.0 support:

### DIFF
--- a/test/invariants/handlers/Handler.sol
+++ b/test/invariants/handlers/Handler.sol
@@ -89,13 +89,15 @@ contract Handler is Test, GrantFundTestHelper {
     }
 
     modifier useRandomActor(uint256 actorIndex) {
-        vm.stopPrank();
-
         address actor = actors[constrictToRange(actorIndex, 0, actors.length - 1)];
         _actor = actor;
-        vm.startPrank(actor);
+
+        try vm.startPrank(_actor) {
+        } catch {
+            changePrank(_actor);
+        }
+
         _;
-        vm.stopPrank();
     }
 
     /*************************/

--- a/test/unit/BurnWrappedToken.t.sol
+++ b/test/unit/BurnWrappedToken.t.sol
@@ -72,7 +72,7 @@ contract BurnWrappedTokenTest is Test {
         assertEq(_wrappedToken.totalSupply(), 0);
 
         // transfer some tokens to the test address
-        changePrank(_tokenDeployer);
+        vm.startPrank(_tokenDeployer);
         _token.approve(address(_tokenDeployer), tokensToWrap);
         _token.transferFrom(_tokenDeployer, _tokenHolder, tokensToWrap);
 
@@ -107,7 +107,7 @@ contract BurnWrappedTokenTest is Test {
         uint256 tokensToWrap = 50 * 1e18;
 
         // transfer some tokens to the test address
-        changePrank(_tokenDeployer);
+        vm.startPrank(_tokenDeployer);
         _token.approve(address(_tokenDeployer), tokensToWrap);
         _token.transferFrom(_tokenDeployer, _tokenHolder, tokensToWrap);
 


### PR DESCRIPTION
Invariant tests - in useRandomActor modifier:
- try to start prank using startPrank, if that fails then fallback to changePrank
- remove stopPrank as not needed (changePrank does stop/startPrank)

Unit tests: fix by using startPrank instead changePrank

