### PR TITLE
Q-AJN-8: Old Version of Solidity

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Analyze GrantFund
         run: |
-          solc-select install 0.8.16 && solc-select use 0.8.16
+          solc-select install 0.8.18 && solc-select use 0.8.18
           slither src/grants/
         continue-on-error: true
         id: fund_analyzer

--- a/script/GrantFund.s.sol
+++ b/script/GrantFund.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { Script }  from "forge-std/Script.sol";
 import { console } from "forge-std/console.sol";

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { IERC20 }    from "@oz/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@oz/token/ERC20/utils/SafeERC20.sol";

--- a/src/grants/base/ExtraordinaryFunding.sol
+++ b/src/grants/base/ExtraordinaryFunding.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { IERC20 }   from "@oz/token/ERC20/IERC20.sol";
 import { SafeCast } from "@oz/utils/math/SafeCast.sol";

--- a/src/grants/base/Funding.sol
+++ b/src/grants/base/Funding.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { Address }         from "@oz/utils/Address.sol";
 import { IVotes }          from "@oz/governance/utils/IVotes.sol";

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { IERC20 }    from "@oz/token/ERC20/IERC20.sol";
 import { SafeCast }  from "@oz/utils/math/SafeCast.sol";

--- a/src/grants/interfaces/IExtraordinaryFunding.sol
+++ b/src/grants/interfaces/IExtraordinaryFunding.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 //slither-disable-next-line solc-version
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 /**
  * @title Ajna Grant Coordination Fund Extraordinary Proposal flow.

--- a/src/grants/interfaces/IFunding.sol
+++ b/src/grants/interfaces/IFunding.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 //slither-disable-next-line solc-version
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 /**
  * @title Ajna Grant Coordination Fund Extraordinary Proposal flow.

--- a/src/grants/interfaces/IGrantFund.sol
+++ b/src/grants/interfaces/IGrantFund.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { IFunding } from "../interfaces/IFunding.sol";
 import { IExtraordinaryFunding } from "../interfaces/IExtraordinaryFunding.sol";

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 //slither-disable-next-line solc-version
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 /**
  * @title Ajna Grant Coordination Fund Standard Proposal flow.

--- a/src/grants/libraries/Maths.sol
+++ b/src/grants/libraries/Maths.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 library Maths {
 

--- a/test/interactions/DrainGrantFund.sol
+++ b/test/interactions/DrainGrantFund.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { IExtraordinaryFunding } from "src/grants/interfaces/IExtraordinaryFunding.sol";
 import { IAjnaToken }            from "../utils/IAjnaToken.sol";

--- a/test/invariants/ExtraordinaryInvariant.t.sol
+++ b/test/invariants/ExtraordinaryInvariant.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { console }  from "@std/console.sol";
 import { SafeCast } from "@oz/utils/math/SafeCast.sol";

--- a/test/invariants/StandardFinalizeInvariant.t.sol
+++ b/test/invariants/StandardFinalizeInvariant.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { console }  from "@std/console.sol";
 import { SafeCast } from "@oz/utils/math/SafeCast.sol";

--- a/test/invariants/StandardFundingInvariant.t.sol
+++ b/test/invariants/StandardFundingInvariant.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { console }  from "@std/console.sol";
 import { SafeCast } from "@oz/utils/math/SafeCast.sol";

--- a/test/invariants/StandardMultipleDistributionInvariant.t.sol
+++ b/test/invariants/StandardMultipleDistributionInvariant.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { console }  from "@std/console.sol";
 import { SafeCast } from "@oz/utils/math/SafeCast.sol";

--- a/test/invariants/StandardScreeningInvariant.t.sol
+++ b/test/invariants/StandardScreeningInvariant.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { console } from "@std/console.sol";
 

--- a/test/invariants/base/ExtraordinaryTestBase.sol
+++ b/test/invariants/base/ExtraordinaryTestBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { console } from "@std/console.sol";
 

--- a/test/invariants/base/ITestBase.sol
+++ b/test/invariants/base/ITestBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 interface ITestBase {
 

--- a/test/invariants/base/StandardTestBase.sol
+++ b/test/invariants/base/StandardTestBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { console } from "@std/console.sol";
 

--- a/test/invariants/base/TestBase.sol
+++ b/test/invariants/base/TestBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { Test }   from "@std/Test.sol";
 

--- a/test/invariants/handlers/ExtraordinaryHandler.sol
+++ b/test/invariants/handlers/ExtraordinaryHandler.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { console }  from "@std/console.sol";
 import { Test }     from "forge-std/Test.sol";

--- a/test/invariants/handlers/Handler.sol
+++ b/test/invariants/handlers/Handler.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { Test }    from "forge-std/Test.sol";
 import { Strings } from "@oz/utils/Strings.sol";
@@ -200,7 +200,7 @@ contract Handler is Test, GrantFundTestHelper {
 
     function randomSeed() internal returns (uint256) {
         counter++;
-        return uint256(keccak256(abi.encodePacked(block.number, block.difficulty, counter)));
+        return uint256(keccak256(abi.encodePacked(block.number, block.prevrandao, counter)));
     }
 
     function getActorsCount() public view returns(uint256) {

--- a/test/invariants/handlers/StandardHandler.sol
+++ b/test/invariants/handlers/StandardHandler.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { console } from "@std/console.sol";
 import { Test }     from "forge-std/Test.sol";

--- a/test/unit/ExtraordinaryFunding.t.sol
+++ b/test/unit/ExtraordinaryFunding.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { GrantFund }             from "../../src/grants/GrantFund.sol";
 import { IExtraordinaryFunding } from "../../src/grants/interfaces/IExtraordinaryFunding.sol";

--- a/test/unit/GrantFund.t.sol
+++ b/test/unit/GrantFund.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { GrantFund }           from "../../src/grants/GrantFund.sol";
 import { IFunding }            from "../../src/grants/interfaces/IFunding.sol";

--- a/test/unit/Maths.t.sol
+++ b/test/unit/Maths.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { Test } from "@std/Test.sol";
 

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { SafeCast }  from "@oz/utils/math/SafeCast.sol";
 

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { SafeCast } from "@oz/utils/math/SafeCast.sol";
 import { Strings }  from "@oz/utils/Strings.sol"; // used for createNProposals
@@ -367,7 +367,7 @@ abstract contract GrantFundTestHelper is Test {
     // Returns a random proposal Index from all proposals
     function _getRandomProposal(uint256 noOfProposals_) internal returns(uint256 proposal_) {
         // calculate random proposal Index between 0 and noOfProposals_
-        proposal_ = uint256(keccak256(abi.encodePacked(block.number, block.difficulty))) % noOfProposals_;
+        proposal_ = uint256(keccak256(abi.encodePacked(block.number, block.prevrandao))) % noOfProposals_;
         vm.roll(block.number + 1);
     }
 
@@ -476,7 +476,7 @@ abstract contract GrantFundTestHelper is Test {
             descriptionPartTwo = string.concat(descriptionPartTwo, ", ");
 
             // generate a random nonce to add to the description string to avoid collisions
-            uint256 randomNonce = uint256(keccak256(abi.encodePacked(block.number, block.difficulty))) % 100;
+            uint256 randomNonce = uint256(keccak256(abi.encodePacked(block.number, block.prevrandao))) % 100;
             descriptionPartTwo = string.concat(descriptionPartTwo, Strings.toString(randomNonce));
         }
         description_ = string(abi.encodePacked(descriptionPartOne, descriptionPartTwo));
@@ -661,7 +661,7 @@ abstract contract GrantFundTestHelper is Test {
     // Returns random votes for a user
     function _randomVote() internal returns (uint256 votes_) {
         // calculate random vote between 1 and 1.25 * 1e18
-        votes_ = 1 + uint256(keccak256(abi.encodePacked(block.number, block.difficulty))) % (1.25 * 1e18);
+        votes_ = 1 + uint256(keccak256(abi.encodePacked(block.number, block.prevrandao))) % (1.25 * 1e18);
         vm.roll(block.number + 1);
     }
 

--- a/test/utils/IAjnaToken.sol
+++ b/test/utils/IAjnaToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.18;
 
 import { IVotes }    from "@oz/governance/utils/IVotes.sol";
 import { IERC20 }      from "@oz/token/ERC20/IERC20.sol";


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Update solidity version from 0.8.16 to 0.8.18
  * The contracts are currently set to be compiled with Solidity version 0.8.16 according to their pragma statements. However, an important bug was fixed in 0.8.17 .

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* update pragmas to 0.8.18
* use `preverando` instead `difficulty` (need a version of foundry containing https://github.com/foundry-rs/foundry/pull/4856)



# Contract size
## Pre Change
```
| Contract              | Size (kB) | Margin (kB) |
|-----------------------|-----------|-------------|
| AjnaToken             | 8.14      | 16.436      |
| BurnWrappedAjna       | 5.277     | 19.299      |
| GrantFund             | 19.422    | 5.154       |
| SigUtils              | 0.549     | 24.027      |
| Maths                 | 0.142     | 24.434      |
```
## Post Change
```
| Contract              | Size (kB) | Margin (kB) |
|-----------------------|-----------|-------------|
| AjnaToken             | 8.14      | 16.436      |
| BurnWrappedAjna       | 5.277     | 19.299      |
| GrantFund             | 19.402    | 5.174       |
| SigUtils              | 0.549     | 24.027      |
| Maths                 | 0.142     | 24.434      |
```

# Gas usage
## Pre Change
```
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |
|---------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                             | Deployment Size |        |        |        |         |
| 4739351                                     | 23668           |        |        |        |         |
| Function Name                               | min             | avg    | median | max    | # calls |
| claimDelegateReward                         | 1407            | 57897  | 58540  | 65340  | 341     |
| executeExtraordinary                        | 7387            | 39097  | 39802  | 95823  | 11      |
| executeStandard                             | 9009            | 30094  | 38140  | 47894  | 8       |
| findMechanismOfProposal                     | 613             | 2043   | 799    | 4719   | 3       |
| fundTreasury                                | 8001            | 45104  | 44641  | 65872  | 29      |
| fundingVote                                 | 1584            | 106444 | 106376 | 409345 | 356     |
| getDelegateReward                           | 2975            | 3465   | 2975   | 5017   | 5       |
| getDistributionId                           | 374             | 410    | 374    | 2374   | 818     |
| getDistributionPeriodInfo                   | 1046            | 1743   | 1046   | 5046   | 86      |
| getExtraordinaryProposalInfo                | 992             | 992    | 992    | 992    | 4       |
| getExtraordinaryProposalSucceeded           | 2245            | 2664   | 2740   | 3008   | 3       |
| getFundedProposalSlate                      | 1133            | 1309   | 1368   | 1368   | 4       |
| getFundingPowerVotes                        | 15500           | 15688  | 15751  | 15751  | 4       |
| getFundingVotesCast                         | 1577            | 2317   | 2317   | 3057   | 2       |
| getMinimumThresholdPercentage               | 471             | 629    | 471    | 2471   | 16      |
| getProposalInfo                             | 980             | 980    | 980    | 980    | 110     |
| getSlateHash                                | 872             | 880    | 884    | 884    | 3       |
| getSliceOfNonTreasury                       | 1577            | 3743   | 1577   | 8077   | 3       |
| getSliceOfTreasury                          | 781             | 1781   | 1781   | 2781   | 2       |
| getTopTenProposals                          | 1187            | 2451   | 2363   | 3304   | 16      |
| getVoterInfo                                | 1002            | 1002   | 1002   | 1002   | 5       |
| getVotesExtraordinary                       | 764             | 7665   | 7681   | 8755   | 887     |
| getVotesFunding                             | 2389            | 6565   | 2797   | 11518  | 15      |
| getVotesScreening                           | 5313            | 5352   | 5347   | 6489   | 697     |
| hasVotedExtraordinary                       | 683             | 1683   | 1683   | 2683   | 2       |
| hashProposal                                | 3843            | 3843   | 3843   | 3843   | 85      |
| proposeExtraordinary                        | 4731            | 63309  | 82166  | 86505  | 18      |
| proposeStandard                             | 4709            | 78463  | 82561  | 82900  | 81      |
| screeningVote                               | 1847            | 44636  | 37699  | 399146 | 375     |
| screeningVotesCast                          | 663             | 1329   | 663    | 2663   | 3       |
| startNewDistributionPeriod                  | 617             | 48521  | 53163  | 75597  | 20      |
| state                                       | 1337            | 4534   | 3934   | 7331   | 20      |
| treasury                                    | 396             | 396    | 396    | 396    | 12      |
| updateSlate                                 | 971             | 58653  | 69985  | 318329 | 17      |
| voteExtraordinary                           | 565             | 29360  | 29458  | 31424  | 884     |


| src/token/AjnaToken.sol:AjnaToken contract |                 |       |        |       |         |
|--------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                            | Deployment Size |       |        |       |         |
| 2200269                                    | 13095           |       |        |       |         |
| Function Name                              | min             | avg   | median | max   | # calls |
| DOMAIN_SEPARATOR                           | 397             | 397   | 397    | 397   | 11      |
| allowance                                  | 778             | 778   | 778    | 778   | 2       |
| approve                                    | 24622           | 24622 | 24622  | 24622 | 1       |
| balanceOf                                  | 584             | 1162  | 584    | 2584  | 38      |
| burn                                       | 23087           | 23087 | 23087  | 23087 | 1       |
| decimals                                   | 245             | 245   | 245    | 245   | 1       |
| delegate                                   | 26825           | 54145 | 69697  | 73004 | 9       |
| delegates                                  | 576             | 576   | 576    | 576   | 6       |
| getPastVotes                               | 1244            | 1600  | 1570   | 2018  | 4       |
| getVotes                                   | 612             | 1368  | 1064   | 2612  | 33      |
| name                                       | 3249            | 3249  | 3249   | 3249  | 1       |
| permit                                     | 51347           | 51347 | 51347  | 51347 | 1       |
| symbol                                     | 3291            | 3291  | 3291   | 3291  | 1       |
| totalSupply                                | 372             | 1705  | 2372   | 2372  | 3       |
| transfer                                   | 594             | 621   | 621    | 649   | 2       |
| transferFrom                               | 24099           | 26819 | 26819  | 29539 | 2       |
| transferFromWithPermit                     | 24390           | 25502 | 25502  | 26614 | 2       |
```
## Post Change
```
|---------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                             | Deployment Size |        |        |        |         |
| 4729342                                     | 23618           |        |        |        |         |
| Function Name                               | min             | avg    | median | max    | # calls |
| claimDelegateReward                         | 1407            | 57738  | 58544  | 65344  | 272     |
| executeExtraordinary                        | 7387            | 44244  | 13091  | 95827  | 5       |
| executeStandard                             | 9009            | 30094  | 38140  | 47894  | 8       |
| findMechanismOfProposal                     | 613             | 2043   | 799    | 4719   | 3       |
| fundTreasury                                | 8001            | 45104  | 44641  | 65872  | 29      |
| fundingVote                                 | 1584            | 106482 | 106384 | 409433 | 287     |
| getDelegateReward                           | 2979            | 3469   | 2979   | 5021   | 5       |
| getDistributionId                           | 374             | 418    | 374    | 2374   | 673     |
| getDistributionPeriodInfo                   | 1046            | 1805   | 1046   | 5046   | 79      |
| getExtraordinaryProposalInfo                | 992             | 992    | 992    | 992    | 3       |
| getExtraordinaryProposalSucceeded           | 2247            | 2668   | 2744   | 3014   | 3       |
| getFundedProposalSlate                      | 1133            | 1309   | 1368   | 1368   | 4       |
| getFundingPowerVotes                        | 15502           | 15690  | 15753  | 15753  | 4       |
| getFundingVotesCast                         | 1577            | 2317   | 2317   | 3057   | 2       |
| getMinimumThresholdPercentage               | 471             | 723    | 471    | 2471   | 9       |
| getProposalInfo                             | 980             | 980    | 980    | 980    | 110     |
| getSlateHash                                | 872             | 880    | 884    | 884    | 3       |
| getSliceOfNonTreasury                       | 1579            | 4829   | 4829   | 8079   | 2       |
| getSliceOfTreasury                          | 783             | 1783   | 1783   | 2783   | 2       |
| getTopTenProposals                          | 1187            | 2451   | 2363   | 3304   | 16      |
| getVoterInfo                                | 1002            | 1002   | 1002   | 1002   | 5       |
| getVotesExtraordinary                       | 764             | 7569   | 7681   | 8755   | 120     |
| getVotesFunding                             | 2389            | 6567   | 2797   | 11522  | 15      |
| getVotesScreening                           | 5313            | 5354   | 5347   | 6489   | 559     |
| hasVotedExtraordinary                       | 683             | 1683   | 1683   | 2683   | 2       |
| hashProposal                                | 3843            | 3843   | 3843   | 3843   | 72      |
| proposeExtraordinary                        | 4731            | 53882  | 86337  | 86507  | 12      |
| proposeStandard                             | 4709            | 78098  | 82889  | 82889  | 74      |
| screeningVote                               | 1847            | 45864  | 40381  | 399146 | 306     |
| screeningVotesCast                          | 663             | 1329   | 663    | 2663   | 3       |
| startNewDistributionPeriod                  | 617             | 48523  | 53165  | 75599  | 20      |
| state                                       | 1337            | 4040   | 3346   | 7333   | 15      |
| treasury                                    | 396             | 396    | 396    | 396    | 6       |
| updateSlate                                 | 971             | 58656  | 69987  | 318349 | 17      |
| voteExtraordinary                           | 565             | 28719  | 29458  | 31424  | 117     |


| src/token/AjnaToken.sol:AjnaToken contract |                 |       |        |       |         |
|--------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                            | Deployment Size |       |        |       |         |
| 2200269                                    | 13095           |       |        |       |         |
| Function Name                              | min             | avg   | median | max   | # calls |
| DOMAIN_SEPARATOR                           | 397             | 397   | 397    | 397   | 11      |
| allowance                                  | 778             | 778   | 778    | 778   | 2       |
| approve                                    | 24622           | 24622 | 24622  | 24622 | 1       |
| balanceOf                                  | 584             | 1162  | 584    | 2584  | 38      |
| burn                                       | 23087           | 23087 | 23087  | 23087 | 1       |
| decimals                                   | 245             | 245   | 245    | 245   | 1       |
| delegate                                   | 26825           | 54145 | 69697  | 73004 | 9       |
| delegates                                  | 576             | 576   | 576    | 576   | 6       |
| getPastVotes                               | 1244            | 1600  | 1570   | 2018  | 4       |
| getVotes                                   | 612             | 1368  | 1064   | 2612  | 33      |
| name                                       | 3249            | 3249  | 3249   | 3249  | 1       |
| permit                                     | 51347           | 51347 | 51347  | 51347 | 1       |
| symbol                                     | 3291            | 3291  | 3291   | 3291  | 1       |
| totalSupply                                | 372             | 1705  | 2372   | 2372  | 3       |
| transfer                                   | 594             | 621   | 621    | 649   | 2       |
| transferFrom                               | 24099           | 26819 | 26819  | 29539 | 2       |
| transferFromWithPermit                     | 24390           | 25502 | 25502  | 26614 | 2       |
```

