### PR TITLE
Q-AJN-7: zero ERC20 transfer on claim reward

### DIFF
--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -261,7 +261,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         );
 
         // transfer rewards to delegatee
-        IERC20(ajnaTokenAddress).safeTransfer(msg.sender, rewardClaimed_);
+        if (rewardClaimed_ != 0) IERC20(ajnaTokenAddress).safeTransfer(msg.sender, rewardClaimed_);
     }
 
     /**
@@ -279,17 +279,17 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         uint256 votingPowerAllocatedByDelegatee = voter_.votingPower - voter_.remainingVotingPower;
 
         // if none of the voter's voting power was allocated, they receive no rewards
-        if (votingPowerAllocatedByDelegatee == 0) return 0;
-
-        // calculate reward
-        // delegateeReward = 10 % of GBC distributed as per delegatee Voting power allocated
-        rewards_ = Maths.wdiv(
-            Maths.wmul(
-                currentDistribution_.fundsAvailable,
-                votingPowerAllocatedByDelegatee
-            ),
-            currentDistribution_.fundingVotePowerCast
-        ) / 10;
+        if (votingPowerAllocatedByDelegatee != 0) {
+            // calculate reward
+            // delegateeReward = 10 % of GBC distributed as per delegatee Voting power allocated
+            rewards_ = Maths.wdiv(
+                Maths.wmul(
+                    currentDistribution_.fundsAvailable,
+                    votingPowerAllocatedByDelegatee
+                ),
+                currentDistribution_.fundingVotePowerCast
+            ) / 10;
+        }
     }
 
     /***********************************/

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -1047,8 +1047,9 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         vm.expectRevert(IStandardFunding.RewardAlreadyClaimed.selector);
         _grantFund.claimDelegateReward(distributionId);
 
-        // transfers 0 ajna Token as _tokenHolder6 has not participated in funding stage
-        _claimDelegateReward(
+        // no ajna tokens transfered as _tokenHolder6 has not participated in funding stage
+        // transfer event should not be emitted
+        _claimZeroDelegateReward(
             {
                 grantFund_:        _grantFund,
                 voter_:            _tokenHolder6,

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -125,6 +125,15 @@ abstract contract GrantFundTestHelper is Test {
         changePrank(voter_);
         vm.expectEmit(true, true, false, true);
         emit DelegateRewardClaimed(voter_, distributionId_, claimedReward_);
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(grantFund_), voter_, claimedReward_);
+        grantFund_.claimDelegateReward(distributionId_);
+    }
+
+    function _claimZeroDelegateReward(GrantFund grantFund_, address voter_, uint24 distributionId_, uint256 claimedReward_) internal {
+        changePrank(voter_);
+        vm.expectEmit(true, true, false, true);
+        emit DelegateRewardClaimed(voter_, distributionId_, claimedReward_);
         grantFund_.claimDelegateReward(distributionId_);
     }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Do not ERC20.transfer if rewards claimed are 0
  * check `rewardClaimed_` is not 0 in `claimDelegateReward()` prior to transferring to the recipient

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* In the case where the caller doesn't have any rewards to claim, gas will be wasted on transferring a zero value.
  * if claimed rewards are 0 then do not attempt to transfer
  * `_getDelegateReward` better readability: minor change to calculate rewards `if (votingPowerAllocatedByDelegatee != 0)` instead `if (votingPowerAllocatedByDelegatee == 0) return 0;`
  * expose unit test

# Contract size
## Pre Change
```
| Contract              | Size (kB) | Margin (kB) |
|-----------------------|-----------|-------------|
| GrantFund             | 19.422    | 5.154       |
```
## Post Change
```
| Contract              | Size (kB) | Margin (kB) |
|-----------------------|-----------|-------------|
| GrantFund             | 19.419    | 5.157       |
```

# Gas usage
## Pre Change
```
| Function Name                               | min             | avg    | median | max    | # calls |
| claimDelegateReward                         | 1407            | 57897  | 58540  | 65340  | 341     |
```
## Post Change
```
| Function Name                               | min             | avg    | median | max    | # calls |
| claimDelegateReward                         | 1407            | 38175  | 36570  | 65359  | 11      |
```

