### PR TITLE
Quantstamp: Code Documentation & Best Practices

### DIFF
--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -55,7 +55,7 @@ contract GrantFund is IGrantFund, ExtraordinaryFunding, StandardFunding {
     ) external view override returns (ProposalState) {
         FundingMechanism mechanism = findMechanismOfProposal(proposalId_);
 
-        return mechanism == FundingMechanism.Standard ? _standardProposalState(proposalId_) : _getExtraordinaryProposalState(proposalId_);
+        return mechanism == FundingMechanism.Standard ? _getStandardProposalState(proposalId_) : _getExtraordinaryProposalState(proposalId_);
     }
 
     /**************************/

--- a/src/grants/base/ExtraordinaryFunding.sol
+++ b/src/grants/base/ExtraordinaryFunding.sol
@@ -136,7 +136,7 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
 
         ExtraordinaryFundingProposal storage proposal = _extraordinaryFundingProposals[proposalId_];
         // revert if proposal is inactive
-        if (proposal.startBlock > block.number || proposal.endBlock < block.number || proposal.executed) {
+        if (proposal.endBlock < block.number || proposal.executed) {
             revert ExtraordinaryFundingProposalInactive();
         }
 
@@ -169,10 +169,10 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
         uint256 minThresholdPercentage = _getMinimumThresholdPercentage();
 
         return
-            // succeeded if proposal's votes received doesn't exceed the minimum threshold required
+            // proposal succeeded if received more votes than tokens requested plus the minimum non treasury threshold required
             (votesReceived >= tokensRequested_ + _getSliceOfNonTreasury(minThresholdPercentage))
             &&
-            // succeeded if tokens requested are available for claiming from the treasury
+            // proposal succeeded if tokens requested are less than treasury threshold required
             (tokensRequested_ <= _getSliceOfTreasury(Maths.WAD - minThresholdPercentage))
         ;
     }

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -205,7 +205,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         uint256 totalTokensRequested;
         uint256 numFundedProposals = fundingProposalIds.length;
 
-        for (uint i = 0; i < numFundedProposals; ) {
+        for (uint256 i = 0; i < numFundedProposals; ) {
             Proposal memory proposal = _standardFundingProposals[fundingProposalIds[i]];
 
             totalTokensRequested += proposal.tokensRequested;
@@ -213,7 +213,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
             unchecked { ++i; }
         }
 
-        // readd non distributed tokens to the treasury
+        // re-add non distributed tokens to the treasury
         treasury += (fundsAvailable - totalTokensRequested);
 
         _isSurplusFundsUpdated[distributionId_] = true;
@@ -314,14 +314,13 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         bytes32 newSlateHash     = keccak256(abi.encode(proposalIds_));
 
         // check if slate of proposals is better than the existing slate, and is thus the new top slate
-        newTopSlate_ = currentSlateHash == 0 ||
-            (currentSlateHash!= 0 && sum > _sumProposalFundingVotes(_fundedProposalSlates[currentSlateHash]));
+        newTopSlate_ = currentSlateHash == 0 || sum > _sumProposalFundingVotes(_fundedProposalSlates[currentSlateHash]);
 
         // if slate of proposals is new top slate, update state
         if (newTopSlate_) {
             uint256[] storage existingSlate = _fundedProposalSlates[newSlateHash];
 
-            for (uint i = 0; i < numProposalsInSlate; ) {
+            for (uint256 i = 0; i < numProposalsInSlate; ) {
 
                 // update list of proposals to fund
                 existingSlate.push(proposalIds_[i]);
@@ -431,7 +430,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         uint256 totalTokensRequested = 0;
 
         // check each proposal in the slate is valid
-        for (uint i = 0; i < numProposalsInSlate_; ) {
+        for (uint256 i = 0; i < numProposalsInSlate_; ) {
             Proposal memory proposal = _standardFundingProposals[proposalIds_[i]];
 
             // check if Proposal is in the topTenProposals list
@@ -444,13 +443,11 @@ abstract contract StandardFunding is Funding, IStandardFunding {
             sum_ += uint128(proposal.fundingVotesReceived); // since we are converting from int128 to uint128, we can safely assume that the value will not overflow
             totalTokensRequested += proposal.tokensRequested;
 
-            // check if slate of proposals exceeded budget constraint ( 90% of GBC )
-            if (totalTokensRequested > (gbc * 9 / 10)) {
-                revert InvalidProposalSlate();
-            }
-
             unchecked { ++i; }
         }
+
+        // check if slate of proposals exceeded budget constraint ( 90% of GBC )
+        if (totalTokensRequested > (gbc * 9 / 10)) revert InvalidProposalSlate();
     }
 
     /**
@@ -465,8 +462,8 @@ abstract contract StandardFunding is Funding, IStandardFunding {
     ) internal pure returns (bool) {
         uint256 numProposals = proposalIds_.length;
 
-        for (uint i = 0; i < numProposals; ) {
-            for (uint j = i + 1; j < numProposals; ) {
+        for (uint256 i = 0; i < numProposals; ) {
+            for (uint256 j = i + 1; j < numProposals; ) {
                 if (proposalIds_[i] == proposalIds_[j]) return true;
 
                 unchecked { ++j; }
@@ -488,7 +485,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
     function _sumProposalFundingVotes(
         uint256[] memory proposalIdSubset_
     ) internal view returns (uint128 sum_) {
-        for (uint i = 0; i < proposalIdSubset_.length;) {
+        for (uint256 i = 0; i < proposalIdSubset_.length;) {
             // since we are converting from int128 to uint128, we can safely assume that the value will not overflow
             sum_ += uint128(_standardFundingProposals[proposalIdSubset_[i]].fundingVotesReceived);
 
@@ -502,7 +499,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
      * @param  proposalId_ The ID of the proposal being checked.
      * @return The proposals status in the ProposalState enum.
      */
-    function _standardProposalState(uint256 proposalId_) internal view returns (ProposalState) {
+    function _getStandardProposalState(uint256 proposalId_) internal view returns (ProposalState) {
         Proposal memory proposal = _standardFundingProposals[proposalId_];
 
         if (proposal.executed)                                                     return ProposalState.Executed;
@@ -660,7 +657,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         uint128 cumulativeVotePowerUsed = SafeCast.toUint128(sumOfTheSquareOfVotesCast);
 
         // check that the voter has enough voting power remaining to cast the vote
-        if (cumulativeVotePowerUsed > votingPower) revert InsufficientVotingPower();
+        if (cumulativeVotePowerUsed > votingPower) revert InsufficientRemainingVotingPower();
 
         // update voter voting power accumulator
         voter_.remainingVotingPower = votingPower - cumulativeVotePowerUsed;
@@ -676,7 +673,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         proposal_.fundingVotesReceived += SafeCast.toInt128(voteParams_.votesUsed);
 
         // the incremental additional votes cast on the proposal to be used as a return value and emit value
-        incrementalVotesUsed_ = SafeCast.toUint256(Maths.abs(voteParams_.votesUsed));
+        incrementalVotesUsed_ = Maths.abs(voteParams_.votesUsed);
 
         // emit VoteCast instead of VoteCastWithParams to maintain compatibility with Tally
         // emits the amount of incremental votes cast for the proposal, not the voting power cost or total votes on a proposal
@@ -712,7 +709,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         proposal_.votesReceived += SafeCast.toUint128(votes_);
 
         // check if proposal was already screened
-        int indexInArray = _findProposalIndex(proposalId, currentTopTenProposals);
+        int256 indexInArray = _findProposalIndex(proposalId, currentTopTenProposals);
         uint256 screenedProposalsLength = currentTopTenProposals.length;
 
         // check if the proposal should be added to the top ten list for the first time
@@ -810,25 +807,25 @@ abstract contract StandardFunding is Funding, IStandardFunding {
      * @dev    Implements the descending insertion sort algorithm.
      * @dev    Counters incremented in an unchecked block due to being bounded by array length.
      * @dev    Since we are converting from int256 to uint256, we can safely assume that the values will not overflow.
-     * @param proposals_        The array of proposals to sort by votes received.
-     * @param targetProposalId_ The targeted proposal id to insert.
+     * @param proposals_           The array of proposals to sort by votes received.
+     * @param targetProposalIndex_ The targeted proposal index to insert in proposals array.
      */
     function _insertionSortProposalsByVotes(
         uint256[] storage proposals_,
-        uint256 targetProposalId_
+        uint256 targetProposalIndex_
     ) internal {
         while (
-            targetProposalId_ != 0
+            targetProposalIndex_ != 0
             &&
-            _standardFundingProposals[proposals_[targetProposalId_]].votesReceived > _standardFundingProposals[proposals_[targetProposalId_ - 1]].votesReceived
+            _standardFundingProposals[proposals_[targetProposalIndex_]].votesReceived > _standardFundingProposals[proposals_[targetProposalIndex_ - 1]].votesReceived
         ) {
             // swap values if left item < right item
-            uint256 temp = proposals_[targetProposalId_ - 1];
+            uint256 temp = proposals_[targetProposalIndex_ - 1];
 
-            proposals_[targetProposalId_ - 1] = proposals_[targetProposalId_];
-            proposals_[targetProposalId_] = temp;
+            proposals_[targetProposalIndex_ - 1] = proposals_[targetProposalIndex_];
+            proposals_[targetProposalIndex_] = temp;
 
-            unchecked { --targetProposalId_; }
+            unchecked { --targetProposalIndex_; }
         }
     }
 
@@ -846,7 +843,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         uint256 numVotesCast = votesCast_.length;
 
         for (uint256 i = 0; i < numVotesCast; ) {
-            votesCastSumSquared_ += Maths.wpow(SafeCast.toUint256(Maths.abs(votesCast_[i].votesUsed)), 2);
+            votesCastSumSquared_ += Maths.wpow(Maths.abs(votesCast_[i].votesUsed), 2);
 
             unchecked { ++i; }
         }

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -33,6 +33,11 @@ interface IStandardFunding {
     error InsufficientVotingPower();
 
     /**
+     * @notice Voter does not have enough voting power remaining to cast the vote.
+     */
+    error InsufficientRemainingVotingPower();
+
+    /**
      * @notice Delegatee attempted to claim delegate reward before the challenge period ended.
      */
     error ChallengePeriodNotEnded();

--- a/src/grants/libraries/Maths.sol
+++ b/src/grants/libraries/Maths.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.18;
 
+import { SafeCast }  from "@oz/utils/math/SafeCast.sol";
+
 library Maths {
 
-    uint256 public constant WAD = 10**18;
+    uint256 internal constant WAD = 10**18;
 
-    function abs(int x) internal pure returns (int) {
-        return x >= 0 ? x : -x;
+    function abs(int256 x) internal pure returns (uint256) {
+        return x >= 0 ? SafeCast.toUint256(x) : SafeCast.toUint256(-x);
     }
 
     /**
@@ -31,11 +33,11 @@ library Maths {
     }
 
     function wmul(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * y + 10**18 / 2) / 10**18;
+        return (x * y + WAD / 2) / WAD;
     }
 
     function wdiv(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * 10**18 + y / 2) / y;
+        return (x * WAD + y / 2) / y;
     }
 
     function min(uint256 x, uint256 y) internal pure returns (uint256) {
@@ -44,7 +46,7 @@ library Maths {
 
     /** @notice Raises a WAD to the power of an integer and returns a WAD */
     function wpow(uint256 x, uint256 n) internal pure returns (uint256 z) {
-        z = n % 2 != 0 ? x : 10**18;
+        z = n % 2 != 0 ? x : WAD;
 
         for (n /= 2; n != 0; n /= 2) {
             x = wmul(x, x);

--- a/test/invariants/StandardMultipleDistributionInvariant.t.sol
+++ b/test/invariants/StandardMultipleDistributionInvariant.t.sol
@@ -208,7 +208,7 @@ contract StandardMultipleDistributionInvariant is StandardTestBase {
     }
 
     function invariant_call_summary() external view {
-        uint24 distributionId = _grantFund.getDistributionId();
+        // uint24 distributionId = _grantFund.getDistributionId();
 
         _standardHandler.logCallSummary();
         _standardHandler.logTimeSummary();

--- a/test/invariants/handlers/StandardHandler.sol
+++ b/test/invariants/handlers/StandardHandler.sol
@@ -202,7 +202,7 @@ contract StandardHandler is Handler {
             numberOfCalls['SFH.fundingVote.success']++;
 
             // check votesCast is equal to the sum of votes cast
-            assertEq(votesCast, SafeCast.toUint256(sumFundingVotes(fundingVoteParams)));
+            assertEq(votesCast, sumFundingVotes(fundingVoteParams));
 
             // update actor funding votes counts
             // find and replace previous vote record for that proposlId, in that distributonId
@@ -313,7 +313,7 @@ contract StandardHandler is Handler {
         }
     }
 
-    function executeStandard(uint256 actorIndex_, uint256 proposalToExecute_) external useCurrentBlock useRandomActor(actorIndex_) {
+    function executeStandard(uint256 actorIndex_, uint256) external useCurrentBlock useRandomActor(actorIndex_) {
         numberOfCalls['SFH.executeStandard']++;
 
         uint24 distributionId = _grantFund.getDistributionId();
@@ -554,7 +554,7 @@ contract StandardHandler is Handler {
                 }
 
                 // check if additional vote would break the happy path
-                if (Maths.wpow(SafeCast.toUint256(Maths.abs(votesToCast)), 2) > votingPower - votingPowerUsed) {
+                if (Maths.wpow(Maths.abs(votesToCast), 2) > votingPower - votingPowerUsed) {
                     // resize array before breaking out of the happy path
                     assembly { mstore(fundingVoteParams_, i) }
                     break;
@@ -879,7 +879,7 @@ contract StandardHandler is Handler {
         uint256 numVotesCast = votesCast_.length;
 
         for (uint256 i = 0; i < numVotesCast; ) {
-            votesCastSumSquared_ += Maths.wpow(SafeCast.toUint256(Maths.abs(votesCast_[i].votesUsed)), 2);
+            votesCastSumSquared_ += Maths.wpow(Maths.abs(votesCast_[i].votesUsed), 2);
 
             unchecked { ++i; }
         }
@@ -892,7 +892,7 @@ contract StandardHandler is Handler {
         }
     }
 
-    function sumFundingVotes(IStandardFunding.FundingVoteParams[] memory fundingVotes_) public pure returns (int256 sum_) {
+    function sumFundingVotes(IStandardFunding.FundingVoteParams[] memory fundingVotes_) public pure returns (uint256 sum_) {
         for (uint256 i = 0; i < fundingVotes_.length; ++i) {
             sum_ += Maths.abs(fundingVotes_[i].votesUsed);
         }

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -231,7 +231,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertEq(votingPower, 625_000_000_000_000 * 1e18 - Maths.wpow(15_000_000 * 1e18, 2));
 
         // check revert if additional votes exceed the budget
-        vm.expectRevert(IStandardFunding.InsufficientVotingPower.selector);
+        vm.expectRevert(IStandardFunding.InsufficientRemainingVotingPower.selector);
         _fundingVoteNoLog(_grantFund, _tokenHolder1, proposal.proposalId, 16_000_000 * 1e18);
     }
 
@@ -446,7 +446,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertEq(fundingVoteParams[0].votesUsed, -25_000_000 * 1e18);
 
         // check revert if attempts to vote again
-        assertInsufficientVotingPowerRevert(_grantFund, _tokenHolder1, testProposals[1].proposalId, -1);
+        assertInsufficientRemainingVotingPowerRevert(_grantFund, _tokenHolder1, testProposals[1].proposalId, -1);
     }
 
     /**
@@ -777,7 +777,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
             votesUsed: -17_500_000 * 1e18
         });
         changePrank(_tokenHolder4);
-        vm.expectRevert(IStandardFunding.InsufficientVotingPower.selector);
+        vm.expectRevert(IStandardFunding.InsufficientRemainingVotingPower.selector);
         _grantFund.fundingVote(fundingVoteParams);
 
         // tokenholder4 divides their full votingpower into two proposals in one transaction

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -751,6 +751,11 @@ abstract contract GrantFundTestHelper is Test {
         _fundingVoteNoLog(grantFund_, voter_, proposalId_, votesAllocated_);
     }
 
+    function assertInsufficientRemainingVotingPowerRevert(GrantFund grantFund_, address voter_, uint256 proposalId_, int256 votesAllocated_) internal {
+        vm.expectRevert(IStandardFunding.InsufficientRemainingVotingPower.selector);
+        _fundingVoteNoLog(grantFund_, voter_, proposalId_, votesAllocated_);
+    }
+
     function assertFundingVoteInvalidVoteRevert(GrantFund grantFund_, address voter_, uint256 proposalId_, int256 votesAllocated_) internal {
         vm.expectRevert(IStandardFunding.InvalidVote.selector);
         _fundingVoteNoLog(grantFund_, voter_, proposalId_, votesAllocated_);


### PR DESCRIPTION
* Code documentation:
  - `StandardFunding.sol : readd -> re-add`: changed
  - `ExtraordinaryFunding.sol` shows unclear comments: updated

* Adherence to Best Practices:
  - `StandardFunding._insertionSortProposalsByVotes` should better name the parameter `targetProposalId_` to
better represent its purpose in the function as an index: renamed to `targetProposalIndex_`
  - In the `Maths` library, there is a `abs()` function that returns the absolute size of a signed integer. It will always be positive, so it makes sense to return it as `uint256` instead of `int`: changed, used `SafeCast.toUint256` inside `Maths.abs` instead where function called
  - `Maths.sol` library should use `WAD` instead of hardcoding the powers: updated, made `WAD` constant internal
  - `proposal.startBlock > block.number` check is redundant in `L139` of `ExtraordinaryFunding.sol`: removed
  - Declare `uint256` instead of `uint`: updated all occurrences, same for `int` to `int256`
  - `_standardProposalState() `can be renamed to `_getStandardProposalState()` or viceversa to be consistent
in both contracts: changed function name
  - The error `InsufficientVotingPower` in `L659` of `StandardFunding.sol` is not descriptive for that case. Consider
creating another error with a different name: created `InsufficientRemainingVotingPower` error, updated tests
  - improvements to `StandardFunding.sol`:
    - `L317` The check can be simplified to `sum > _sumProposalFundingVotes(_fundedProposalSlates[currentSlateHash])`: remove redundant check
    - `L448` The check can be moved after the for loop: moved check after loop
    - `L679`, `L849` `SafeCast` is not necessary in these statements: removed with `Maths.abs` change