### PR TITLE
Q-AJN-2: Locked Funds Due to Non-Executable Proposals

### DIFF
--- a/src/grants/base/Funding.sol
+++ b/src/grants/base/Funding.sol
@@ -124,6 +124,8 @@ abstract contract Funding is IFunding, ReentrancyGuard {
             }
             if (selector != bytes4(0xa9059cbb)) revert InvalidProposal();
 
+            // TODO: check address in calldata as well isn't 0 address or the token address or this contract
+
             // https://github.com/ethereum/solidity/issues/9439
             // retrieve tokensRequested from incoming calldata, accounting for selector and recipient address
             uint256 tokensRequested;

--- a/src/grants/base/Funding.sol
+++ b/src/grants/base/Funding.sol
@@ -124,16 +124,19 @@ abstract contract Funding is IFunding, ReentrancyGuard {
             }
             if (selector != bytes4(0xa9059cbb)) revert InvalidProposal();
 
-            // TODO: check address in calldata as well isn't 0 address or the token address or this contract
-
             // https://github.com/ethereum/solidity/issues/9439
-            // retrieve tokensRequested from incoming calldata, accounting for selector and recipient address
+            // retrieve recipient and tokensRequested from incoming calldata, accounting for the function selector
             uint256 tokensRequested;
+            address recipient;
             bytes memory tokenDataWithSig = calldatas_[i];
             //slither-disable-next-line assembly
             assembly {
-                tokensRequested := mload(add(tokenDataWithSig, 68))
+                recipient := mload(add(tokenDataWithSig, 36)) // 36 = 4 (selector) + 32 (recipient address)
+                tokensRequested := mload(add(tokenDataWithSig, 68)) // 68 = 4 (selector) + 32 (recipient address) + 32 (tokens requested)
             }
+
+            // check recipient in the calldata is valid and doesn't attempt to transfer tokens to a disallowed address
+            if (recipient == address(0) || recipient == ajnaTokenAddress || recipient == address(this)) revert InvalidProposal();
 
             // update tokens requested for additional calldata
             tokensRequested_ += SafeCast.toUint128(tokensRequested);

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -523,7 +523,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
 
         vm.roll(_startBlock + 200);
 
-        TestProposalParams[] memory testProposalParams = new TestProposalParams[](15);
+        TestProposalParams[] memory testProposalParams = new TestProposalParams[](14);
         testProposalParams[0] = TestProposalParams(_tokenHolder1, 9_000_000 * 1e18);
         testProposalParams[1] = TestProposalParams(_tokenHolder2, 2_000_000 * 1e18);
         testProposalParams[2] = TestProposalParams(_tokenHolder3, 5_000_000 * 1e18);
@@ -591,7 +591,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
 
         vm.roll(_startBlock + 200);
 
-        TestProposalParams[] memory testProposalParams = new TestProposalParams[](15);
+        TestProposalParams[] memory testProposalParams = new TestProposalParams[](14);
         testProposalParams[0] = TestProposalParams(_tokenHolder1, 9_000_000 * 1e18);
         testProposalParams[1] = TestProposalParams(_tokenHolder2, 3_000_000 * 1e18);
         testProposalParams[2] = TestProposalParams(_tokenHolder3, 5_000_000 * 1e18);
@@ -940,7 +940,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
 
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0xd2cf686d5946419f8c1c2f3d087ac34cc3bdf8501d0c3c9bbac434e393120576);
+        assertEq(slateHash, 0xdb759d0c238c273204a32cddf58fafe694f14ee3fd946599da558887864f5ba5);
         // check funded proposal slate matches expected state
         GrantFund.Proposal[] memory fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 1);
@@ -956,7 +956,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertTrue(proposalSlateUpdated);
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0x6e33dadb2eeccb23524892ce6220d4ccf984b94498871aaae1dad9b261e46b8b);
+        assertEq(slateHash, 0xc0791749a5fd3c47b484429b4f83ecae279d6d969fb7e4523d0c9ac65ef1374d);
         // check funded proposal slate matches expected state
         fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
@@ -980,7 +980,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertTrue(proposalSlateUpdated);
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0x737cc7e504574db633adb9a17783dc8aaadd1497828787dd5795b24161b2d9b2);
+        assertEq(slateHash, 0xd8b6f16122e47d7ed6b0e827fdfcc5cb2acd84a702ce698d24922f534878f474);
         // check funded proposal slate matches expected state
         fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
@@ -995,7 +995,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
 
         // check funded proposal slate wasn't updated
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0x737cc7e504574db633adb9a17783dc8aaadd1497828787dd5795b24161b2d9b2);
+        assertEq(slateHash, 0xd8b6f16122e47d7ed6b0e827fdfcc5cb2acd84a702ce698d24922f534878f474);
         fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
         assertEq(fundedProposalSlate[0].proposalId, screenedProposals[0].proposalId);

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -245,8 +245,7 @@ abstract contract GrantFundTestHelper is Test {
         uint256 proposalId = grantFund_.proposeStandard(targets_, values_, calldatas_, description);
         assertEq(proposalId, expectedProposalId);
 
-        (GeneratedTestProposalParams[] memory params, uint256 totalTokensRequested) = _getGeneratedTestProposalParamsFromParams(targets_, values_, calldatas_);
-        return TestProposal(proposalId, distributionId, description, totalTokensRequested, block.number, params);
+        return _createTestProposalStandard(distributionId, proposalId, targets_, values_, calldatas_, description);
     }
 
     function _createNProposals(GrantFund grantFund_, IAjnaToken token_, TestProposalParams[] memory testProposalParams_) internal returns (TestProposal[] memory) {
@@ -279,6 +278,12 @@ abstract contract GrantFundTestHelper is Test {
             testProposals[i] = proposal;
         }
         return testProposals;
+    }
+
+    // return a TestProposal struct containing the state of a created proposal
+    function _createTestProposalStandard(uint24 distributionId_, uint256 proposalId_, address[] memory targets_, uint256[] memory values_, bytes[] memory calldatas_, string memory description) internal returns (TestProposal memory proposal_) {
+        (GeneratedTestProposalParams[] memory params, uint256 totalTokensRequested) = _getGeneratedTestProposalParamsFromParams(targets_, values_, calldatas_);
+        proposal_ = TestProposal(proposalId_, distributionId_, description, totalTokensRequested, block.number, params);
     }
 
     /**

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -260,11 +260,12 @@ abstract contract GrantFundTestHelper is Test {
         TestProposal[] memory testProposals = new TestProposal[](testProposalParams_.length);
 
         for (uint256 i = 0; i < testProposalParams_.length; ++i) {
-            // generate description string
+            // generate description string from data
             string memory descriptionPartOne = "Proposal to transfer ";
             string memory descriptionPartTwo = Strings.toString(testProposalParams_[i].tokensRequested);
-            string memory descriptionPartThree = " tokens to tester address";
-            string memory description = string(abi.encodePacked(descriptionPartOne, descriptionPartTwo, descriptionPartThree));
+            string memory descriptionPartThree = " tokens to recipient ";
+            string memory descriptionPartFour = Strings.toHexString(testProposalParams_[i].recipient);
+            string memory description = string(abi.encodePacked(descriptionPartOne, descriptionPartTwo, descriptionPartThree, descriptionPartFour));
 
             // generate calldata
             bytes[] memory proposalCalldata = new bytes[](1);


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Validate `recipient` field in `_validateCalldatas` as part of proposal creation, fixing Q-AJN-2.
  * Check that the provided address isn't the 0 address, the Ajna token contract, or the grant fund contract itself. If any of the calldatas have an address set to one of those, the proposal creation will fail in both mechanisms.
  * Add new test `testInvalidRecipientCalldata` to ensure invalid proposal calldatas can't be created.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Q-AJN-2: Locked Funds Due to Non-Executable Proposals
* Funds could be unreachable if invalid calldata proposals make it through the funding mechanism and can't be executed as the funds won't be returned to the treasury.