### PR TITLE
Q-AJN-1: Delegate Rewards Calculation Takes Into Account All Funding Voters

### DIFF
--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -559,7 +559,6 @@ abstract contract StandardFunding is Funding, IStandardFunding {
             votesCast_ += _fundingVote(
                 currentDistribution,
                 proposal,
-                msg.sender,
                 voter,
                 voteParams_[i]
             );
@@ -604,7 +603,6 @@ abstract contract StandardFunding is Funding, IStandardFunding {
      * @dev    Votes can be allocated to multiple proposals, quadratically, for or against.
      * @param  currentDistribution_  The current distribution period.
      * @param  proposal_             The current proposal being voted upon.
-     * @param  account_              The voting account.
      * @param  voter_                The voter data struct tracking available votes.
      * @param  voteParams_           The amount of votes being allocated to the proposal. Not squared. If less than 0, vote is against.
      * @return incrementalVotesUsed_ The amount of funding stage votes allocated to the proposal.
@@ -612,7 +610,6 @@ abstract contract StandardFunding is Funding, IStandardFunding {
     function _fundingVote(
         QuarterlyDistribution storage currentDistribution_,
         Proposal storage proposal_,
-        address account_,
         QuadraticVoter storage voter_,
         FundingVoteParams memory voteParams_
     ) internal returns (uint256 incrementalVotesUsed_) {
@@ -684,7 +681,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         // emit VoteCast instead of VoteCastWithParams to maintain compatibility with Tally
         // emits the amount of incremental votes cast for the proposal, not the voting power cost or total votes on a proposal
         emit VoteCast(
-            account_,
+            msg.sender,
             proposalId,
             support,
             incrementalVotesUsed_,

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -670,7 +670,10 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         uint256 incrementalVotingPowerUsed = uint256(cumulativeVotePowerUsed - voterPowerUsedPreVote);
 
         // update accumulator for total voting power used in the funding stage in order to calculate delegate rewards
-        currentDistribution_.fundingVotePowerCast += incrementalVotingPowerUsed;
+        // check that the voter voted in the screening round before updating the accumulator
+        if (screeningVotesCast[_currentDistributionId][msg.sender] != 0) {
+            currentDistribution_.fundingVotePowerCast += incrementalVotingPowerUsed;
+        }
 
         // update proposal vote tracking
         proposal_.fundingVotesReceived += SafeCast.toInt128(voteParams_.votesUsed);


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Add check in `_fundingVote` ensuring a voter voted in the screening stage before adding their votes to the total funding vote accumulator used in the delegation rewards calculation.
* Add `testSingleRoundVoting` to test how delegation rewards handles voters who only participate in some of the rounds.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Q-AJN-1: Delegate Rewards Calculation Takes Into Account All Funding
* The protocol should account for users that have not voted in the screening round and hence should not be entitled to the
rewards.
* https://github.com/code-423n4/2023-05-ajna-findings/issues/224


# Gas usage
## Pre Change
```
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |                                                                                                             
|---------------------------------------------|-----------------|--------|--------|--------|---------|                                                                                                             
| Deployment Cost                             | Deployment Size |        |        |        |         |                                                                                                             
| 3903082                                     | 19502           |        |        |        |         |                                                                                                             
| Function Name                               | min             | avg    | median | max    | # calls |                                                                                                             
| claimDelegateReward                         | 1456            | 58052  | 58494  | 65294  | 507     |                                                                                                             
| executeExtraordinary                        | 7595            | 30004  | 11474  | 95872  | 13      |                                                                                                             
| executeStandard                             | 9220            | 23418  | 9811   | 47758  | 5       |                                                                                                             
| findMechanismOfProposal                     | 635             | 2067   | 821    | 4747   | 3       |                                                                                                             
| fundTreasury                                | 8186            | 41876  | 44826  | 67373  | 32      |                                                                                                             
| fundingVote                                 | 1669            | 104772 | 104569 | 410573 | 517     |                                                                                                             
| getDelegateReward                           | 3069            | 3559   | 3069   | 5111   | 5       |                                                                                                             
| getDistributionId                           | 351             | 376    | 351    | 2351   | 1112    |                                                                                                             
| getDistributionPeriodInfo                   | 1059            | 1859   | 1059   | 5059   | 55      |                                                                                                             
| getExtraordinaryProposalInfo                | 1017            | 1017   | 1017   | 1017   | 8       |                                                                                                             
| getExtraordinaryProposalSucceeded           | 2431            | 2852   | 2928   | 3198   | 3       |                                                                                                             
| getFundedProposalSlate                      | 1133            | 1309   | 1368   | 1368   | 4       |                                                                                                             
| getFundingVotesCast                         | 1601            | 2341   | 2341   | 3081   | 2       |                                                                                                             
| getMinimumThresholdPercentage               | 493             | 657    | 493    | 2493   | 22      |                                                                                                             
| getProposalInfo                             | 1032            | 1032   | 1032   | 1032   | 98      |                                                                                                             
| getSlateHash                                | 933             | 941    | 945    | 945    | 3       |                                                                                                             
| getSliceOfNonTreasury                       | 1739            | 2953   | 1739   | 10239  | 7       |                                                                                                             
| getSliceOfTreasury                          | 760             | 1760   | 1760   | 2760   | 2       |                                                                                                             
| getTopTenProposals                          | 1164            | 2557   | 2340   | 3281   | 13      |                                                                                                             
| getVoterInfo                                | 1078            | 1078   | 1078   | 1078   | 5       |                                                                                                             
| getVotesExtraordinary                       | 810             | 6491   | 5948   | 8394   | 1032    |                                                                                                             
| getVotesFunding                             | 2467            | 6570   | 2875   | 11805  | 15      |                                                                                                             
| getVotesScreening                           | 5153            | 5159   | 5153   | 7153   | 1026    |                                                                                                             
| hasVotedExtraordinary                       | 717             | 1717   | 1717   | 2717   | 2       |                                                                                                             
| hashProposal                                | 3985            | 3985   | 3985   | 3985   | 60      |                                                                                                             
| proposeExtraordinary                        | 4960            | 66597  | 82722  | 89061  | 20      |                                                                                                             
| proposeStandard                             | 4916            | 77402  | 83415  | 85415  | 54      |                                                                                                             
| screeningVote                               | 1950            | 36689  | 34580  | 398973 | 536     |                                                                                                             
| screeningVotesCast                          | 675             | 1341   | 675    | 2675   | 3       |                                                                                                             
| startNewDistributionPeriod                  | 629             | 49379  | 53222  | 53222  | 16      |                                                                                                             
| state                                       | 1593            | 5175   | 5845   | 7562   | 20      |                                                                                                             
| treasury                                    | 396             | 396    | 396    | 396    | 14      |                                                                                                             
| updateSlate                                 | 1002            | 38596  | 31718  | 78803  | 14      |                                                                                                             
| voteExtraordinary                           | 571             | 28073  | 27772  | 31772  | 1029    |
```
## Post Change
```
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |                                                                                                             
|---------------------------------------------|-----------------|--------|--------|--------|---------|                                                                                                             
| Deployment Cost                             | Deployment Size |        |        |        |         |                                                                                                             
| 3911499                                     | 19544           |        |        |        |         |                                                                                                             
| Function Name                               | min             | avg    | median | max    | # calls |                                                                                                             
| claimDelegateReward                         | 1456            | 58052  | 58494  | 65294  | 507     |                                                                                                             
| executeExtraordinary                        | 7595            | 36082  | 26578  | 95872  | 10      |                                                                                                             
| executeStandard                             | 9220            | 23418  | 9811   | 47758  | 5       |                                                                                                             
| findMechanismOfProposal                     | 635             | 2067   | 821    | 4747   | 3       |                                                                                                             
| fundTreasury                                | 8186            | 41876  | 44826  | 67373  | 32      |                                                                                                             
| fundingVote                                 | 1669            | 106973 | 106894 | 412805 | 517     |                                                                                                             
| getDelegateReward                           | 3069            | 3559   | 3069   | 5111   | 5       |                                                                                                             
| getDistributionId                           | 351             | 375    | 351    | 2351   | 1148    |                                                                                                             
| getDistributionPeriodInfo                   | 1059            | 1542   | 1059   | 5059   | 91      |                                                                                                             
| getExtraordinaryProposalInfo                | 1017            | 1017   | 1017   | 1017   | 5       |                                                                                                             
| getExtraordinaryProposalSucceeded           | 2431            | 2852   | 2928   | 3198   | 3       |                                                                                                             
| getFundedProposalSlate                      | 1133            | 1309   | 1368   | 1368   | 4       |                                                                                                             
| getFundingVotesCast                         | 1601            | 2341   | 2341   | 3081   | 2       |                                                                                                             
| getMinimumThresholdPercentage               | 493             | 668    | 493    | 2493   | 16      |                                                                                                             
| getProposalInfo                             | 1032            | 1032   | 1032   | 1032   | 107     |                                                                                                             
| getSlateHash                                | 933             | 941    | 945    | 945    | 3       |                                                                                                             
| getSliceOfNonTreasury                       | 1739            | 3864   | 1739   | 10239  | 4       |                                                                                                             
| getSliceOfTreasury                          | 760             | 1760   | 1760   | 2760   | 2       |                                                                                                             
| getTopTenProposals                          | 1635            | 2720   | 2340   | 3281   | 13      |                                                                                                             
| getVoterInfo                                | 1078            | 1078   | 1078   | 1078   | 5       |                                                                                                             
| getVotesExtraordinary                       | 810             | 6604   | 5948   | 8394   | 657     |                                                                                                             
| getVotesFunding                             | 2467            | 6570   | 2875   | 11805  | 15      |                                                                                                             
| getVotesScreening                           | 5153            | 5159   | 5153   | 7153   | 1026    |                                                                                                             
| hasVotedExtraordinary                       | 717             | 1717   | 1717   | 2717   | 2       |                                                                                                             
| hashProposal                                | 3985            | 3985   | 3985   | 3985   | 93      |                                                                                                             
| proposeExtraordinary                        | 4960            | 63751  | 82722  | 89061  | 17      |                                                                                                             
| proposeStandard                             | 4916            | 79536  | 82738  | 85415  | 90      |                                                                                                             
| screeningVote                               | 1950            | 42308  | 37742  | 398973 | 536     |                                                                                                             
| screeningVotesCast                          | 675             | 1341   | 675    | 2675   | 3       |                                                                                                             
| startNewDistributionPeriod                  | 629             | 49379  | 53222  | 53222  | 16      |                                                                                                             
| state                                       | 1593            | 5057   | 5749   | 7562   | 17      |                                                                                                             
| treasury                                    | 396             | 396    | 396    | 396    | 11      |                                                                                                             
| updateSlate                                 | 1002            | 56365  | 31718  | 318842 | 14      |                                                                                                             
| voteExtraordinary                           | 571             | 28068  | 27772  | 31772  | 654     |  
```

