### PR TITLE
Code Arena 451: add delay to proposeExtraordinary start block

### DIFF
--- a/src/grants/base/ExtraordinaryFunding.sol
+++ b/src/grants/base/ExtraordinaryFunding.sol
@@ -111,7 +111,7 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
         if (newProposal.proposalId != 0) revert ProposalAlreadyExists();
 
         // check proposal length is within limits of 1 month maximum
-        if (block.number + MAX_EFM_PROPOSAL_LENGTH < endBlock_) revert InvalidProposal();
+        if ((block.number + 1) + MAX_EFM_PROPOSAL_LENGTH < endBlock_) revert InvalidProposal();
 
         uint128 totalTokensRequested = _validateCallDatas(targets_, values_, calldatas_);
 
@@ -122,7 +122,7 @@ abstract contract ExtraordinaryFunding is Funding, IExtraordinaryFunding {
 
         // store newly created proposal
         newProposal.proposalId      = proposalId_;
-        newProposal.startBlock      = SafeCast.toUint128(block.number);
+        newProposal.startBlock      = SafeCast.toUint128(block.number + 1); // set start block to one block ahead to prevent back running
         newProposal.endBlock        = SafeCast.toUint128(endBlock_);
         newProposal.tokensRequested = totalTokensRequested;
 

--- a/src/grants/interfaces/IExtraordinaryFunding.sol
+++ b/src/grants/interfaces/IExtraordinaryFunding.sol
@@ -59,6 +59,8 @@ interface IExtraordinaryFunding {
 
     /**
      * @notice Submit a proposal to the extraordinary funding flow.
+     * @dev    The proposal will be rejected if the proposal already exists, or if it's parameters were invalid.
+     * @dev    The start block is set to the next block to prevent proposals from being voted on in the same block as creation.
      * @param endBlock_            Block number of the end of the extraordinary funding proposal voting period.
      * @param targets_             Array of addresses to send transactions to.
      * @param values_              Array of values to send with transactions.

--- a/test/unit/ExtraordinaryFunding.t.sol
+++ b/test/unit/ExtraordinaryFunding.t.sol
@@ -120,6 +120,8 @@ contract ExtraordinaryFundingGrantFundTest is GrantFundTestHelper {
             "Extraordinary Proposal for Ajna token transfer to tester address"
         );
 
+        vm.roll(block.number + 1);
+
         // check voting power is greater than 0 for extant proposal
         uint256 votingPower = _grantFund.getVotesExtraordinary(_tokenHolder1, testProposal.proposalId);
         assertEq(votingPower, 20_000_000 * 1e18);
@@ -168,6 +170,9 @@ contract ExtraordinaryFundingGrantFundTest is GrantFundTestHelper {
             calldatas,
             "Extraordinary Proposal for Ajna token transfer to tester address"
         );
+
+        // roll to proposal start block
+        vm.roll(_startBlock + 51);
 
         // check voting power at vote start
         uint256 votingPower = _grantFund.getVotesExtraordinary(_tokenHolder1, testProposal.proposalId);
@@ -278,7 +283,7 @@ contract ExtraordinaryFundingGrantFundTest is GrantFundTestHelper {
         assertEq(proposalId, testProposal.proposalId);
         assertEq(tokensRequested, tokensRequestedParam);
         assertEq(tokensRequested, testProposal.totalTokensRequested);
-        assertEq(startBlock, block.number);
+        assertEq(startBlock, block.number + 1);
         assertEq(endBlock, endBlockParam);
         assertEq(votesReceived, 0);
         // assertFalse(succeeded);
@@ -581,6 +586,9 @@ contract ExtraordinaryFundingGrantFundTest is GrantFundTestHelper {
 
         // create and submit N Extraordinary proposals 
         TestProposalExtraordinary[] memory testProposals = _getNExtraOridinaryProposals(noOfProposals, _grantFund, _tokenHolder1, _token, tokenRequested);
+
+        // roll forward to new proposal's start blocks
+        vm.roll(_startBlock + 101);
 
         // each tokenHolder(fixed in setup) votes on all proposals
         for(uint i = 0; i < _votersArr.length; i++) {

--- a/test/unit/interactions/DrainGrantFund.sol
+++ b/test/unit/interactions/DrainGrantFund.sol
@@ -1,9 +1,12 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.18;
+
+import { Test } from "@std/Test.sol";
 
 import { IExtraordinaryFunding } from "src/grants/interfaces/IExtraordinaryFunding.sol";
 import { IAjnaToken }            from "../../utils/IAjnaToken.sol";
 
-contract DrainGrantFund {
+contract DrainGrantFund is Test{
     constructor(
         address ajnaToken,
         IExtraordinaryFunding grantFund,
@@ -31,6 +34,9 @@ contract DrainGrantFund {
 
         // attacker creates and submits her proposal
         uint256 proposalId = grantFund.proposeExtraordinary(endBlock, targets, values, calldatas, description);
+
+        // roll blocks forward to allow voting on the proposal at the start block the next block ahead
+        vm.roll(block.number + 1);
 
         // attacker is going to make every token holder vote in favor of her proposal
         for (uint i = 0; i < tokenHolders.length; i++) {


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Add one block delay to the start block of `proposeExtraordinary`. This makes it more difficult to attackers to manipulate the treasury and token supply temporarily with an eye on securing a successful extraordinary proposal
  * Updates tests.
  * Wasn't able to create a new local variable `startBlock` to reduce duplicate computations due to a stack too deep error.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* https://github.com/code-423n4/2023-05-ajna-findings/issues/451

