### PR TITLE
Code Arena 266: Fix _standardProposalState active check

### DIFF
--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -529,7 +529,7 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         Proposal memory proposal = _standardFundingProposals[proposalId_];
 
         if (proposal.executed)                                                     return ProposalState.Executed;
-        else if (_distributions[proposal.distributionId].endBlock >= block.number) return ProposalState.Active;
+        else if (_distributions[proposal.distributionId].endBlock > block.number)  return ProposalState.Active;
         else if (_standardFundingVoteSucceeded(proposalId_))                      return ProposalState.Succeeded;
         else                                                                       return ProposalState.Defeated;
     }


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Fix bug in _getStandardProposal marking the last block in the distribution as inactive incorrectly. https://github.com/code-423n4/2023-05-ajna-findings/issues/266
* https://github.com/code-423n4/2023-05-ajna-findings/issues/31
