### PR TITLE
Code Arena: Delegation reward claiming as soon as distribution period ends

### DIFF
--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -241,8 +241,8 @@ abstract contract StandardFunding is Funding, IStandardFunding {
 
         QuarterlyDistribution memory currentDistribution = _distributions[distributionId_];
 
-        // Check if Challenge Period is still active
-        if(block.number <= _getChallengeStageEndBlock(currentDistribution.endBlock)) revert ChallengePeriodNotEnded();
+        // Check if the distribution period is still active
+        if(block.number <= currentDistribution.endBlock) revert DistributionPeriodStillActive();
 
         // check rewards haven't already been claimed
         if(hasClaimedReward[distributionId_][msg.sender]) revert RewardAlreadyClaimed();

--- a/src/grants/interfaces/IStandardFunding.sol
+++ b/src/grants/interfaces/IStandardFunding.sol
@@ -13,7 +13,7 @@ interface IStandardFunding {
     /**************/
 
     /**
-     * @notice User attempted to execute a proposal before the distribution period ended.
+     * @notice User attempted to start a new distribution or claim delegation rewards before the distribution period ended.
      */
      error DistributionPeriodStillActive();
 
@@ -36,11 +36,6 @@ interface IStandardFunding {
      * @notice Voter does not have enough voting power remaining to cast the vote.
      */
     error InsufficientRemainingVotingPower();
-
-    /**
-     * @notice Delegatee attempted to claim delegate reward before the challenge period ended.
-     */
-    error ChallengePeriodNotEnded();
 
     /**
      * @notice User provided a slate of proposalIds that is invalid.

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -940,6 +940,10 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         vm.expectRevert(IStandardFunding.InvalidProposalSlate.selector);
         _grantFund.updateSlate(potentialProposalSlate, distributionId);
 
+        // should revert if user tries to claim rewards before the distribution period ends
+        vm.expectRevert(IStandardFunding.DistributionPeriodStillActive.selector);
+        _grantFund.claimDelegateReward(distributionId);
+
         /************************/
         /*** Challenge Period ***/
         /************************/
@@ -1051,10 +1055,6 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         // check can't execute proposals prior to the end of the challenge period
         vm.expectRevert(IStandardFunding.ExecuteProposalInvalid.selector);
         _executeProposalNoLog(_grantFund, _token, testProposals[0]);
-
-        // should revert if user tries to claim reward in before challenge Period ends
-        vm.expectRevert(IStandardFunding.ChallengePeriodNotEnded.selector);
-        _grantFund.claimDelegateReward(distributionId);
 
         /********************************/
         /*** Execute Funded Proposals ***/


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Enable voters to claim their delegation rewards as soon as the distribution period ends, instead of having to wait for the challenge stage to end as in the prior implementation. 
  * Also resolves a bug in the prior implementation with inconsistent stage checks: 
  * https://github.com/code-423n4/2023-05-ajna-findings/issues/386
  * https://github.com/code-423n4/2023-05-ajna-findings/issues/187

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->
