### PR TITLE
Fix update treasury with delegate rewards bug

### DIFF
--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -202,19 +202,23 @@ abstract contract StandardFunding is Funding, IStandardFunding {
 
         uint256[] memory fundingProposalIds = _fundedProposalSlates[fundedSlateHash];
 
-        uint256 totalTokensRequested;
+        uint256 totalTokenDistributed;
         uint256 numFundedProposals = fundingProposalIds.length;
 
         for (uint i = 0; i < numFundedProposals; ) {
             Proposal memory proposal = _standardFundingProposals[fundingProposalIds[i]];
 
-            totalTokensRequested += proposal.tokensRequested;
+            totalTokenDistributed += proposal.tokensRequested;
 
             unchecked { ++i; }
         }
 
+        uint256 totalDelegateRewards;
+        // Increament totalTokenDistributed by delegate rewards if anyone has voted during funding voting
+        if (_distributions[distributionId_].fundingVotePowerCast != 0) totalDelegateRewards = (fundsAvailable / 10);
+
         // readd non distributed tokens to the treasury
-        treasury += (fundsAvailable - totalTokensRequested);
+        treasury += (fundsAvailable - totalTokenDistributed - totalDelegateRewards);
 
         _isSurplusFundsUpdated[distributionId_] = true;
     }

--- a/src/grants/base/StandardFunding.sol
+++ b/src/grants/base/StandardFunding.sol
@@ -214,10 +214,10 @@ abstract contract StandardFunding is Funding, IStandardFunding {
         }
 
         uint256 totalDelegateRewards;
-        // Increament totalTokenDistributed by delegate rewards if anyone has voted during funding voting
+        // Increment totalTokenDistributed by delegate rewards if anyone has voted during funding voting
         if (_distributions[distributionId_].fundingVotePowerCast != 0) totalDelegateRewards = (fundsAvailable / 10);
 
-        // readd non distributed tokens to the treasury
+        // re-add non distributed tokens to the treasury
         treasury += (fundsAvailable - totalTokenDistributed - totalDelegateRewards);
 
         _isSurplusFundsUpdated[distributionId_] = true;

--- a/test/invariants/INVARIANTS.md
+++ b/test/invariants/INVARIANTS.md
@@ -9,7 +9,7 @@
 - #### Distribution Period:
     - **DP1**: Only one distribution period should be active at a time. Each successive distribution period's start block should be greater than the previous periods end block.
     - **DP2**: Each winning proposal successfully claims no more that what was finalized in the challenge stage
-    - **DP3**: A distribution's fundsAvailable should be equal to 2% of the treasurie's balance at the block `startNewDistributionPeriod()` is called.
+    - **DP3**: A distribution's fundsAvailable should be equal to 3% of the treasurie's balance at the block `startNewDistributionPeriod()` is called.
     - **DP4**: A distribution's endBlock should be greater than its startBlock.
     - **DP5**: The treasury balance should be greater than the sum of the funds available in all distribution periods.
     - **DP6**: Surplus funds from distribution periods whose token's requested in the final funded slate was less than the total funds available are readded to the treasury.

--- a/test/invariants/INVARIANTS.md
+++ b/test/invariants/INVARIANTS.md
@@ -9,7 +9,7 @@
 - #### Distribution Period:
     - **DP1**: Only one distribution period should be active at a time. Each successive distribution period's start block should be greater than the previous periods end block.
     - **DP2**: Each winning proposal successfully claims no more that what was finalized in the challenge stage
-    - **DP3**: A distribution's fundsAvailable should be equal to 3% of the treasurie's balance at the block `startNewDistributionPeriod()` is called.
+    - **DP3**: A distribution's fundsAvailable should be equal to 3% of the treasury's balance at the block `startNewDistributionPeriod()` is called.
     - **DP4**: A distribution's endBlock should be greater than its startBlock.
     - **DP5**: The treasury balance should be greater than the sum of the funds available in all distribution periods.
     - **DP6**: Surplus funds from distribution periods whose token's requested in the final funded slate was less than the total funds available are readded to the treasury.

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -1157,7 +1157,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         _grantFund.claimDelegateReward(distributionId);
     }
 
-    function testTreasureUpdatedWithSurplusTokens() external {
+    function testTreasuryUpdatedWithSurplusTokens() external {
         // 14 tokenholders self delegate their tokens to enable voting on the proposals
         _selfDelegateVoters(_token, _votersArr);
 

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -1016,8 +1016,8 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         vm.expectRevert(IStandardFunding.InvalidProposalSlate.selector);
         _grantFund.updateSlate(potentialProposalSlate, distributionId);
 
-        // should revert if user tries to claim rewards before the distribution period ends
-        vm.expectRevert(IStandardFunding.DistributionPeriodStillActive.selector);
+        // should revert if user tries to claim rewards and he has not voted in screening stage
+        vm.expectRevert(IStandardFunding.DelegateRewardInvalid.selector);
         _grantFund.claimDelegateReward(distributionId);
 
         /************************/

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -1110,6 +1110,184 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         _grantFund.claimDelegateReward(distributionId);
     }
 
+    function testTreasureUpdatedWithSurplusTokens() external {
+        // 14 tokenholders self delegate their tokens to enable voting on the proposals
+        _selfDelegateVoters(_token, _votersArr);
+
+        vm.roll(_startBlock + 150);
+
+        assertEq(_grantFund.getDistributionId(), 0);
+
+        /*********************************/
+        /*** First Distribution Period ***/
+        /*********************************/
+
+        // start first distribution
+        _startDistributionPeriod(_grantFund);
+
+        uint24 distributionId = _grantFund.getDistributionId();
+        assertEq(distributionId, 1);
+
+        // check funds available
+        uint256 treasuryAtId1 = _grantFund.treasury();
+        assertEq(treasuryAtId1, treasury * 97 / 100);
+        (, , , uint128 gbc_distribution1, , ) = _grantFund.getDistributionPeriodInfo(distributionId);
+        assertEq(gbc_distribution1, 15_000_000 * 1e18);
+        assertEq(gbc_distribution1, _getDistributionFundsAvailable(gbc_distribution1, treasuryAtId1));
+
+        // create 1 proposal paying out tokens and token requested to be maximum (90% of distribution gbc)
+        TestProposalParams[] memory testProposalParams = new TestProposalParams[](1);
+        testProposalParams[0] = TestProposalParams(_tokenHolder1, gbc_distribution1 * 9 / 10);
+        TestProposal[] memory testProposals_distribution1 = _createNProposals(_grantFund, _token, testProposalParams);
+        assertEq(testProposals_distribution1.length, 1);
+
+        vm.roll(_startBlock + 200);
+
+        // screening period votes
+        _screeningVote(_grantFund, _tokenHolder1, testProposals_distribution1[0].proposalId, _getScreeningVotes(_grantFund, _tokenHolder1));
+
+        // skip time to move from screening period to funding period
+        vm.roll(_startBlock + 600_000);
+
+        // check topTenProposals array is correct after screening period - only 1 should have advanced
+        GrantFund.Proposal[] memory screenedProposals_distribution1 = _getProposalListFromProposalIds(_grantFund, _grantFund.getTopTenProposals(distributionId));
+        assertEq(screenedProposals_distribution1.length, 1);
+
+        // funding period votes
+        _fundingVote(_grantFund, _tokenHolder1, screenedProposals_distribution1[0].proposalId, voteYes, 25_000_000 * 1e18);
+
+        // skip to the Challenge period
+        vm.roll(_startBlock + 650_000);
+
+        // updateSlate
+        uint256[] memory potentialProposalSlate = new uint256[](1);
+        potentialProposalSlate[0] = screenedProposals_distribution1[0].proposalId;
+        _grantFund.updateSlate(potentialProposalSlate, distributionId);
+
+        // skip to the end of Challenge period
+        vm.roll(_startBlock + 700_000);
+
+        // check proposal status is succeeded
+        IFunding.ProposalState proposalState = _grantFund.state(testProposals_distribution1[0].proposalId);
+        assertEq(uint8(proposalState), uint8(IFunding.ProposalState.Succeeded));
+
+        // execute funded proposals
+        _executeProposal(_grantFund, _token, testProposals_distribution1[0]);
+
+        // check proposal status updates to executed
+        proposalState = _grantFund.state(testProposals_distribution1[0].proposalId);
+        assertEq(uint8(proposalState), uint8(IFunding.ProposalState.Executed));
+
+        // Claim delegate Rewards
+        _claimDelegateReward(
+            {
+                grantFund_:        _grantFund,
+                voter_:            _tokenHolder1,
+                distributionId_:   distributionId,
+                claimedReward_:    gbc_distribution1 / 10
+            }
+        );
+
+        // Ensure that treasury is equals to token balance in grantFund if all funds available in distribution
+        // are utilized after distribution ends, proposals are executed and delegate claims rewards
+        assertEq(_token.balanceOf(address(_grantFund)), _grantFund.treasury());
+
+        /**********************************/
+        /*** Second Distribution Period ***/
+        /**********************************/
+
+        // start second distribution after the slate has been finalized and the challenge stage is complete.
+        _startDistributionPeriod(_grantFund);
+
+        uint24 distributionId2 = _grantFund.getDistributionId();
+        assertEq(distributionId2, 2);
+
+        // Treasury after start for second distribution should be equals to
+        // 97% of treasury at distribution 1 if all the funds are used
+        uint256 treasuryAtId2 = _grantFund.treasury();
+        assertEq(treasuryAtId2, treasuryAtId1 * 97 / 100);
+        (, , , uint128 gbc_distribution2, , ) = _grantFund.getDistributionPeriodInfo(distributionId2);
+        assertEq(gbc_distribution2, 14_550_000 * 1e18);
+        
+        // create 1 proposal paying out tokens
+        testProposalParams = new TestProposalParams[](1);
+        testProposalParams[0] = TestProposalParams(_tokenHolder1, 10_000_000 * 1e18);
+        TestProposal[] memory testProposals_distribution2 = _createNProposals(_grantFund, _token, testProposalParams);
+        assertEq(testProposals_distribution2.length, 1);
+
+        vm.roll(_startBlock + 700_200);
+
+        // screening period votes
+        _screeningVote(_grantFund, _tokenHolder1, testProposals_distribution2[0].proposalId, _getScreeningVotes(_grantFund, _tokenHolder1));
+
+        // skip time to move from screening period to funding period
+        vm.roll(_startBlock + 1_300_000);
+
+        // check topTenProposals array is correct after screening period - only 1 should have advanced
+        GrantFund.Proposal[] memory screenedProposals_distribution2 = _getProposalListFromProposalIds(_grantFund, _grantFund.getTopTenProposals(2));
+        assertEq(screenedProposals_distribution2.length, 1);
+
+        // funding period votes
+        _fundingVote(_grantFund, _tokenHolder1, screenedProposals_distribution2[0].proposalId, voteYes, 25_000_000 * 1e18);
+
+        // skip to the Challenge period
+        vm.roll(_startBlock + 1_350_000);
+
+        // updateSlate
+        potentialProposalSlate = new uint256[](1);
+        potentialProposalSlate[0] = screenedProposals_distribution2[0].proposalId;
+        _grantFund.updateSlate(potentialProposalSlate, distributionId2);
+
+        // skip to the end of Challenge period
+        vm.roll(_startBlock + 1_400_000);
+
+        // check proposal status is succeeded
+        proposalState = _grantFund.state(testProposals_distribution2[0].proposalId);
+        assertEq(uint8(proposalState), uint8(IFunding.ProposalState.Succeeded));
+
+        // execute funded proposals
+        _executeProposal(_grantFund, _token, testProposals_distribution2[0]);
+
+        // check proposal status updates to executed
+        proposalState = _grantFund.state(testProposals_distribution2[0].proposalId);
+        assertEq(uint8(proposalState), uint8(IFunding.ProposalState.Executed));
+
+        // Claim delegate Rewards
+        _claimDelegateReward(
+            {
+                grantFund_:        _grantFund,
+                voter_:            _tokenHolder1,
+                distributionId_:   distributionId2,
+                claimedReward_:    gbc_distribution2 / 10
+            }
+        );
+
+        // assert that token balance is greater than treasury as token distributed is less than total funds available
+        assertGt(_token.balanceOf(address(_grantFund)), _grantFund.treasury());
+
+        /**********************************/
+        /*** Third Distribution Period ***/
+        /**********************************/
+
+        // start second distribution after the slate has been finalized and the challenge stage is complete.
+        _startDistributionPeriod(_grantFund);
+
+        uint24 distributionId3 = _grantFund.getDistributionId();
+        assertEq(distributionId3, 3);
+
+        // Treasury after start for second distribution should be greater than
+        // 97% of treasury at distribution 1 as all the funds are not used
+        uint256 treasuryAtId3 = _grantFund.treasury();
+        assertGt(treasuryAtId3, treasuryAtId2 * 97 / 100);
+
+        // Ensure surplus amount is added into treasury after new distribution starts
+        uint256 surplus = getSurplusTokensInDistribution(_grantFund, distributionId2);
+        assertEq(treasuryAtId3, (treasuryAtId2 + surplus) * 97 / 100);
+        (, , , uint128 gbc_distribution3, , ) = _grantFund.getDistributionPeriodInfo(distributionId3);
+        assertEq(gbc_distribution3, 14_206_350 * 1e18);
+
+    }
+
     /**
      *  @notice Test GBC calculations for 4 consecutive distributions.
      */ 

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -579,9 +579,11 @@ abstract contract GrantFundTestHelper is Test {
     }
 
     function getSurplusTokensInDistribution(GrantFund grantFund_, uint24 distributionId_) public view returns (uint256 surplus_) {
-        (, , , uint128 fundsAvailable, , bytes32 topSlateHash) = grantFund_.getDistributionPeriodInfo(distributionId_);
+        (, , , uint128 fundsAvailable, uint256 fundingVotePowerCast, bytes32 topSlateHash) = grantFund_.getDistributionPeriodInfo(distributionId_);
         uint256 tokensRequested = getTokensRequestedInFundedSlate(grantFund_, topSlateHash);
-        surplus_ = fundsAvailable - tokensRequested;
+        uint256 totalDelegateRewards;
+        if (fundingVotePowerCast != 0) totalDelegateRewards = fundsAvailable / 10;
+        surplus_ = fundsAvailable - tokensRequested - totalDelegateRewards;
     }
 
     /************************/


### PR DESCRIPTION
# Description of change
## High level
* Update treasury with unused delegation rewards when there are no funding votes.

# Description of bug or vulnerability and solution
* `UpdateTreasury` method always updated the treasury with delegate rewards whether or not the user has voted in the funding stage which led to the possibility of treasury amount more than the token balance>
* Fixed this by updating treasury with delegate rewards only when no users vote in the funding stage.
* https://github.com/code-423n4/2023-05-ajna-findings/issues/461
* https://github.com/code-423n4/2023-05-ajna-findings/issues/450
* https://github.com/code-423n4/2023-05-ajna-findings/issues/289
* https://github.com/code-423n4/2023-05-ajna-findings/issues/263

