### PR TITLE
Remove prefix string from proposal description

### DIFF
--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -422,7 +422,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
     function _getDescriptionHash(
         string memory description_
     ) internal pure returns (bytes32) {
-        return keccak256(abi.encode(DESCRIPTION_PREFIX_HASH_STANDARD, keccak256(bytes(description_))));
+        return keccak256(bytes(description_));
     }
 
     /**

--- a/src/grants/base/Storage.sol
+++ b/src/grants/base/Storage.sol
@@ -24,11 +24,6 @@ abstract contract Storage is IGrantFundState {
     uint256 internal constant CHALLENGE_PERIOD_LENGTH = 50400;
 
     /**
-     * @notice Keccak hash of a prefix string for standard funding mechanism
-     */
-    bytes32 internal constant DESCRIPTION_PREFIX_HASH_STANDARD = keccak256(bytes("Standard Funding: "));
-
-    /**
      * @notice Length of the distribution period in blocks.
      * @dev    Roughly equivalent to the number of blocks in 90 days.
      */

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -1045,7 +1045,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
 
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0xdb759d0c238c273204a32cddf58fafe694f14ee3fd946599da558887864f5ba5);
+        assertEq(slateHash, 0xb36c09a99b14fc310feda1993f754e8f1736a38a3964fbe7df49a709ab7ba290);
         // check funded proposal slate matches expected state
         GrantFund.Proposal[] memory fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 1);
@@ -1061,7 +1061,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertTrue(proposalSlateUpdated);
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0xc0791749a5fd3c47b484429b4f83ecae279d6d969fb7e4523d0c9ac65ef1374d);
+        assertEq(slateHash, 0xec5d3ed74d17bd70f9a01e2761c6d9120e87633b09efdce6ea6042fa63daa176);
         // check funded proposal slate matches expected state
         fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
@@ -1085,7 +1085,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertTrue(proposalSlateUpdated);
         // check slate hash
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0xd8b6f16122e47d7ed6b0e827fdfcc5cb2acd84a702ce698d24922f534878f474);
+        assertEq(slateHash, 0x30c7490b37dc594c92bd64ee2eb0398256044d56e14d86d959c0a9a623c51d43);
         // check funded proposal slate matches expected state
         fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
@@ -1100,7 +1100,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
 
         // check funded proposal slate wasn't updated
         (, , , , , slateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
-        assertEq(slateHash, 0xd8b6f16122e47d7ed6b0e827fdfcc5cb2acd84a702ce698d24922f534878f474);
+        assertEq(slateHash, 0x30c7490b37dc594c92bd64ee2eb0398256044d56e14d86d959c0a9a623c51d43);
         fundedProposalSlate = _getProposalListFromProposalIds(_grantFund, _grantFund.getFundedProposalSlate(slateHash));
         assertEq(fundedProposalSlate.length, 2);
         assertEq(fundedProposalSlate[0].proposalId, screenedProposals[0].proposalId);

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -171,7 +171,7 @@ abstract contract GrantFundTestHelper is Test {
 
     function _createProposal(GrantFund grantFund_, address proposer_, address[] memory targets_, uint256[] memory values_, bytes[] memory calldatas_, string memory description) internal returns (TestProposal memory) {
         // generate expected proposal state
-        uint256 expectedProposalId = grantFund_.hashProposal(targets_, values_, calldatas_, keccak256(abi.encode(keccak256(bytes("Standard Funding: ")), keccak256(bytes(description)))));
+        uint256 expectedProposalId = grantFund_.hashProposal(targets_, values_, calldatas_, keccak256(bytes(description)));
         uint256 startBlock = block.number.toUint64();
         uint24 distributionId = grantFund_.getDistributionId();
 


### PR DESCRIPTION
# Description of change
## High level
* Description prefix was added to prevent collision of `proposalIds` of Extraordinary Funding and Standard Funding #64 . Removed prefix string from description since the extraordinary funding mechanism is removed.