### PR TITLE
Merge challenge stage with distribution period

### DIFF
--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -92,9 +92,9 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
     /**************************************************/
 
     /**
-     * @notice Get the block number at which this distribution period's challenge stage ends.
-     * @param  endBlock_ The end block of a distribution period to get the challenge stage end block for.
-     * @return The block number at which this distribution period's challenge stage ends.
+     * @notice Get the block number at which this distribution period's challenge stage starts.
+     * @param  endBlock_ The end block of a distribution period to get the challenge stage start block for.
+     * @return The block number at which this distribution period's challenge stage starts.
     */
     function _getChallengeStageStartBlock(
         uint256 endBlock_
@@ -102,6 +102,11 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         return endBlock_ - CHALLENGE_PERIOD_LENGTH;
     }
 
+    /**
+     * @notice Get the block number at which this distribution period's funding stage ends.
+     * @param  startBlock_ The end block of a distribution period to get the funding stage end block for.
+     * @return The block number at which this distribution period's funding stage ends.
+    */
     function _getFundingStageEndBlock(
         uint256 startBlock_
     ) internal pure returns(uint256) {
@@ -1128,26 +1133,26 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         return keccak256(abi.encode(proposalIds_));
     }
 
-    function getStage() external view returns (string memory stage_) {
+    /// @inheritdoc IGrantFundActions
+    function getStage() external view returns (bytes32 stage_) {
         DistributionPeriod memory currentDistribution = _distributions[_currentDistributionId];
         uint256 startBlock = currentDistribution.startBlock;
         uint256 endBlock = currentDistribution.endBlock;
         uint256 screeningStageEndBlock = _getScreeningStageEndBlock(startBlock);
         uint256 fundingStageEndBlock = _getFundingStageEndBlock(startBlock);
 
-        // TODO: check there is never overlap between stages on a block
         if (block.number <= screeningStageEndBlock) {
-            stage_ = "Screening";
+            stage_ = keccak256(bytes("Screening"));
         }
         else if (block.number > screeningStageEndBlock && block.number <= fundingStageEndBlock) {
-            stage_ = "Funding";
+            stage_ = keccak256(bytes("Funding"));
         }
         else if (block.number > fundingStageEndBlock && block.number <= endBlock) {
-            stage_ = "Challenge";
+            stage_ = keccak256(bytes("Challenge"));
         }
         else {
             // a new distribution period needs to be started
-            stage_ = "Pending";
+            stage_ = keccak256(bytes("Pending"));
         }
     }
 

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -42,7 +42,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
 
         // update Treasury with unused funds from last distribution period
         {
-            // checks if any [revious distribtuion period exists and its unused funds weren't yet re-added into the treasury
+            // checks if any previous distribtuion period exists and its unused funds weren't yet re-added into the treasury
             if (currentDistributionId > 1 && !_isSurplusFundsUpdated[currentDistributionId - 1]) {
                 // Add unused funds to treasury
                 _updateTreasury(currentDistributionId);

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -40,17 +40,11 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         // check that there isn't currently an active distribution period
         if (block.number <= currentDistributionEndBlock) revert DistributionPeriodStillActive();
 
-        // update Treasury with unused funds from last two distributions
+        // update Treasury with unused funds from last distribution period
         {
-            // // Check if any last distribution exists and its challenge stage is over
-            // if (currentDistributionId > 0 && (block.number > _getChallengeStageEndBlock(currentDistributionEndBlock))) {
-            //     // Add unused funds from last distribution to treasury
-            //     _updateTreasury(currentDistributionId);
-            // }
-
-            // checks if any second last distribution exist and its unused funds are not added into treasury
-            if (currentDistributionId > 1 && !_isSurplusFundsUpdated[currentDistributionId]) {
-                // Add unused funds from second last distribution to treasury
+            // checks if any [revious distribtuion period exists and its unused funds weren't yet re-added into the treasury
+            if (currentDistributionId > 1 && !_isSurplusFundsUpdated[currentDistributionId - 1]) {
+                // Add unused funds to treasury
                 _updateTreasury(currentDistributionId);
             }
         }

--- a/src/grants/base/Storage.sol
+++ b/src/grants/base/Storage.sol
@@ -27,13 +27,19 @@ abstract contract Storage is IGrantFundState {
      * @notice Length of the distribution period in blocks.
      * @dev    Roughly equivalent to the number of blocks in 90 days.
      */
-    uint48 internal constant DISTRIBUTION_PERIOD_LENGTH = 648000;
+    uint48 internal constant DISTRIBUTION_PERIOD_LENGTH = 698400;
 
     /**
-     * @notice Length of the funding phase of the distribution period in blocks.
+     * @notice Length of the funding stage of the distribution period in blocks.
      * @dev    Roughly equivalent to the number of blocks in 10 days.
      */
     uint256 internal constant FUNDING_PERIOD_LENGTH = 72000;
+
+    /**
+     * @notice Length of the screening stage of the distribution period in blocks.
+     * @dev    Roughly equivalent to the number of blocks in 80 days.
+     */
+    uint256 internal constant SCREENING_PERIOD_LENGTH = 576000;
 
     /**
      * @notice Number of blocks prior to a given voting stage to check an accounts voting power.

--- a/src/grants/base/Storage.sol
+++ b/src/grants/base/Storage.sol
@@ -25,7 +25,7 @@ abstract contract Storage is IGrantFundState {
 
     /**
      * @notice Length of the distribution period in blocks.
-     * @dev    Roughly equivalent to the number of blocks in 90 days.
+     * @dev    Roughly equivalent to the number of blocks in 97 days.
      */
     uint48 internal constant DISTRIBUTION_PERIOD_LENGTH = 698400;
 

--- a/src/grants/interfaces/IGrantFundActions.sol
+++ b/src/grants/interfaces/IGrantFundActions.sol
@@ -238,6 +238,13 @@ interface IGrantFundActions is IGrantFundState {
     ) external pure returns (bytes32);
 
     /**
+     * @notice Retrieve a bytes32 hash of the current distribution period stage.
+     * @dev    Used to check if the distribution period is in the screening, funding, or challenge stages.
+     * @return stage_ The hash of the current distribution period stage.
+     */
+    function getStage() external view returns (bytes32 stage_);
+
+    /**
      * @notice Retrieve the top ten proposals that have received the most votes in a given distribution period's screening round.
      * @dev    It may return less than 10 proposals if less than 10 have been submitted. 
      * @dev    Values are subject to change if the queried distribution period's screening round is ongoing.

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -782,7 +782,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         assertEq(id, currentDistributionId);
         assertEq(fundingVotesCast, 0);
         assertEq(startBlock, block.number);
-        assertEq(endBlock, block.number + 648000);
+        assertEq(endBlock, block.number + 698400);
         
         vm.roll(_startBlock + 100);
         currentDistributionId = _grantFund.getDistributionId();
@@ -793,7 +793,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         _grantFund.startNewDistributionPeriod();
 
         // skip forward past the end of the distribution period to allow starting a new distribution
-        vm.roll(_startBlock + 650_000);
+        vm.roll(_startBlock + 700_000);
 
         _startDistributionPeriod(_grantFund);
         currentDistributionId = _grantFund.getDistributionId();

--- a/test/utils/GrantFundTestHelper.sol
+++ b/test/utils/GrantFundTestHelper.sol
@@ -157,7 +157,7 @@ abstract contract GrantFundTestHelper is Test {
 
     function _startDistributionPeriod(GrantFund grantFund_) internal returns (uint24 distributionId) {
         vm.expectEmit(true, true, false, true);
-        emit DistributionPeriodStarted(grantFund_.getDistributionId() + 1, block.number, block.number + 648000);
+        emit DistributionPeriodStarted(grantFund_.getDistributionId() + 1, block.number, block.number + 698400);
         distributionId = grantFund_.startNewDistributionPeriod();
     }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Add the 7 day challenge period into the distribution period itself. Each distribution period is now fully sequential.
  * The distribution period length is now expanded to 698400 blocks. The previous length + the challenge stage length.
  * The distribution period's end block is now the challenge stage end block. The distribution period's funding stage end block is now one block before the challenge stage starts.
  * The length of each stage are unchanged.
  * No other business logic changes.
  * Remove unnecessary clause from `startNewDistributionPeriod` checking previous periods for surplus funds to re-add to the treasury. This is now handled automatically with each distribution period automatically taking the full surplus from its predecessor.
  * Add new `testStage` unit test that rolls to each block of interest and checks the systems stage.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* [Issue non valid but recommended mitigation suggested this change](https://github.com/code-423n4/2023-05-ajna-findings/issues/387)
