### PR TITLE
Voter info restructuring for gas optimizations

### DIFF
--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -999,12 +999,13 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
      */
     function _getVotesScreening(uint24 distributionId_, address account_) internal view returns (uint256 votes_) {
         uint256 startBlock = _distributions[distributionId_].startBlock;
+        uint256 snapshotBlock = startBlock - 1;
 
         // calculate voting weight based on the number of tokens held at the snapshot blocks of the screening stage
         votes_ = _getVotesAtSnapshotBlocks(
             account_,
-            startBlock - VOTING_POWER_SNAPSHOT_DELAY,
-            startBlock
+            snapshotBlock - VOTING_POWER_SNAPSHOT_DELAY,
+            snapshotBlock
         );
     }
 
@@ -1042,9 +1043,10 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
 
      /**
      * @notice Retrieve the voting power of an account.
-     * @dev    Voting power is the minimum of the amount of votes available at a snapshot block 33 blocks prior to voting start, and at the vote starting block.
+     * @dev    Voting power is the minimum of the amount of votes available at two snapshots:
+     *         a snapshot 34 blocks prior to voting start, and the second snapshot the block before the distribution period starts.
      * @param account_        The voting account.
-     * @param snapshot_       One of the block numbers to retrieve the voting power at. 33 blocks prior to the block at which a proposal is available for voting.
+     * @param snapshot_       One of the block numbers to retrieve the voting power at. 34 blocks prior to the block at which a proposal is available for voting.
      * @param voteStartBlock_ The block number the proposal became available for voting.
      * @return                The voting power of the account.
      */
@@ -1055,13 +1057,10 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
     ) internal view returns (uint256) {
         IVotes token = IVotes(ajnaTokenAddress);
 
-        // calculate the number of votes available at the snapshot block
+        // calculate the number of votes available at the first snapshot block
         uint256 votes1 = token.getPastVotes(account_, snapshot_);
 
-        // enable voting weight to be calculated during the voting period's start block
-        voteStartBlock_ = voteStartBlock_ != block.number ? voteStartBlock_ : block.number - 1;
-
-        // calculate the number of votes available at the stage's start block
+        // calculate the number of votes available at the second snapshot occuring the block before the stage's start block
         uint256 votes2 = token.getPastVotes(account_, voteStartBlock_);
 
         return Maths.min(votes2, votes1);

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -194,8 +194,10 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
     function claimDelegateReward(
         uint24 distributionId_
     ) external override returns (uint256 rewardClaimed_) {
+        VoterInfo storage voter = _voterInfo[distributionId_][msg.sender];
+
         // Revert if delegatee didn't vote in screening stage
-        if (screeningVotesCast[distributionId_][msg.sender] == 0) revert DelegateRewardInvalid();
+        if (voter.screeningVotesCast == 0) revert DelegateRewardInvalid();
 
         DistributionPeriod storage currentDistribution = _distributions[distributionId_];
 
@@ -203,15 +205,12 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         if (block.number <= currentDistribution.endBlock) revert DistributionPeriodStillActive();
 
         // check rewards haven't already been claimed
-        mapping(address => bool) storage _hasClaimedReward = hasClaimedReward[distributionId_];
-        if (_hasClaimedReward[msg.sender]) revert RewardAlreadyClaimed();
-
-        QuadraticVoter storage voter = _quadraticVoters[distributionId_][msg.sender];
+        if (voter.hasClaimedReward) revert RewardAlreadyClaimed();
 
         // calculate rewards earned for voting
         rewardClaimed_ = _getDelegateReward(currentDistribution, voter);
 
-        _hasClaimedReward[msg.sender] = true;
+        voter.hasClaimedReward = true;
 
         emit DelegateRewardClaimed(
             msg.sender,
@@ -232,10 +231,10 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
      */
     function _getDelegateReward(
         DistributionPeriod storage currentDistribution_,
-        QuadraticVoter storage voter_
+        VoterInfo storage voter_
     ) internal view returns (uint256 rewards_) {
         // calculate the total voting power available to the voter that was allocated in the funding stage
-        uint256 votingPowerAllocatedByDelegatee = voter_.votingPower - voter_.remainingVotingPower;
+        uint256 votingPowerAllocatedByDelegatee = voter_.fundingVotingPower - voter_.fundingRemainingVotingPower;
         // take the sqrt of the voting power allocated to compare against the root of all voting power allocated
         // multiply by 1e18 to maintain WAD precision
         uint256 rootVotingPowerAllocatedByDelegatee = Math.sqrt(votingPowerAllocatedByDelegatee * 1e18);
@@ -630,7 +629,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         uint24 currentDistributionId = _currentDistributionId;
 
         DistributionPeriod storage currentDistribution = _distributions[currentDistributionId];
-        QuadraticVoter     storage voter               = _quadraticVoters[currentDistributionId][msg.sender];
+        VoterInfo          storage voter               = _voterInfo[currentDistributionId][msg.sender];
 
         uint256 startBlock = currentDistribution.startBlock;
 
@@ -639,7 +638,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         // check that the funding stage is active
         if (block.number <= screeningStageEndBlock || block.number > _getFundingStageEndBlock(startBlock)) revert InvalidVote();
 
-        uint128 votingPower = voter.votingPower;
+        uint128 votingPower = voter.fundingVotingPower;
 
         // if this is the first time a voter has attempted to vote this period,
         // set initial voting power and remaining voting power
@@ -650,13 +649,13 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
                 _getVotesFunding(
                     msg.sender,
                     votingPower,
-                    voter.remainingVotingPower,
+                    voter.fundingRemainingVotingPower,
                     screeningStageEndBlock
                 )
             );
 
-            voter.votingPower          = newVotingPower;
-            voter.remainingVotingPower = newVotingPower;
+            voter.fundingVotingPower          = newVotingPower;
+            voter.fundingRemainingVotingPower = newVotingPower;
         }
 
         uint256 numVotesCast = voteParams_.length;
@@ -738,7 +737,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
     function _fundingVote(
         DistributionPeriod storage currentDistribution_,
         Proposal storage proposal_,
-        QuadraticVoter storage voter_,
+        VoterInfo storage voter_,
         FundingVoteParams calldata voteParams_
     ) internal returns (uint256 incrementalVotesUsed_) {
         uint8   support = 1;
@@ -747,10 +746,10 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         // determine if voter is voting for or against the proposal
         voteParams_.votesUsed < 0 ? support = 0 : support = 1;
 
-        uint128 votingPower = voter_.votingPower;
+        uint128 votingPower = voter_.fundingVotingPower;
 
         // the total amount of voting power used by the voter before this vote executes
-        uint128 voterPowerUsedPreVote = votingPower - voter_.remainingVotingPower;
+        uint128 voterPowerUsedPreVote = votingPower - voter_.fundingRemainingVotingPower;
 
         FundingVoteParams[] storage votesCast = voter_.votesCast;
 
@@ -790,7 +789,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         if (cumulativeVotePowerUsed > votingPower) revert InsufficientRemainingVotingPower();
 
         // update voter voting power accumulator
-        voter_.remainingVotingPower = votingPower - cumulativeVotePowerUsed;
+        voter_.fundingRemainingVotingPower = votingPower - cumulativeVotePowerUsed;
 
         // calculate the total sqrt voting power used in the funding stage, in order to calculate delegate rewards.
         // since we are moving from uint128 to uint256, we can safely assume that the value will not overflow.
@@ -800,7 +799,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
 
         // update accumulator for total root voting power used in the funding stage in order to calculate delegate rewards
         // check that the voter voted in the screening round before updating the accumulator
-        if (screeningVotesCast[_currentDistributionId][msg.sender] != 0) {
+        if (voter_.screeningVotesCast != 0) {
             currentDistribution_.fundingVotePowerCast += incrementalRootVotingPowerUsed;
         }
 
@@ -833,9 +832,10 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         uint24 distributionId = proposal_.distributionId;
 
         // check that the voter has enough voting power to cast the vote
-        uint256 pastScreeningVotesCast = screeningVotesCast[distributionId][msg.sender];
+        VoterInfo storage voter = _voterInfo[distributionId][msg.sender];
+        // uint256 pastScreeningVotesCast = screeningVotesCast[distributionId][msg.sender];
         if (
-            pastScreeningVotesCast + votes_ > _getVotesScreening(distributionId, msg.sender)
+            uint256(voter.screeningVotesCast) + votes_ > _getVotesScreening(distributionId, msg.sender)
         ) revert InsufficientVotingPower();
 
         uint256[] storage currentTopTenProposals = _topTenProposals[distributionId];
@@ -873,7 +873,8 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         }
 
         // record voters vote
-        screeningVotesCast[distributionId][msg.sender] = pastScreeningVotesCast + votes_;
+        // screeningVotesCast[distributionId][msg.sender] = pastScreeningVotesCast + votes_;
+        voter.screeningVotesCast += SafeCast.toUint248(votes_);
 
         // emit VoteCast instead of VoteCastWithParams to maintain compatibility with Tally
         emit VoteCast(
@@ -1094,7 +1095,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         address voter_
     ) external view override returns (uint256 rewards_) {
         DistributionPeriod storage currentDistribution = _distributions[distributionId_];
-        QuadraticVoter     storage voter               = _quadraticVoters[distributionId_][voter_];
+        VoterInfo     storage voter               = _voterInfo[distributionId_][voter_];
 
         rewards_ = _getDelegateReward(currentDistribution, voter);
     }
@@ -1135,7 +1136,12 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         uint24 distributionId_,
         address account_
     ) external view override returns (FundingVoteParams[] memory) {
-        return _quadraticVoters[distributionId_][account_].votesCast;
+        return _voterInfo[distributionId_][account_].votesCast;
+    }
+
+    /// @inheritdoc IGrantFundActions
+    function getHasClaimedRewards(uint256 distributionId_, address account_) external view override returns (bool) {
+        return _voterInfo[distributionId_][account_].hasClaimedReward;
     }
 
     /// @inheritdoc IGrantFundActions
@@ -1155,6 +1161,11 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
     /// @inheritdoc IGrantFundActions
     function getScreeningStageEndBlock(uint256 startBlock_) external pure override returns (uint256) {
         return _getScreeningStageEndBlock(startBlock_);
+    }
+
+    /// @inheritdoc IGrantFundActions
+    function getScreeningVotesCast(uint256 distributionId_, address account_) external view override returns (uint256) {
+        return _voterInfo[distributionId_][account_].screeningVotesCast;
     }
 
     /// @inheritdoc IGrantFundActions
@@ -1200,9 +1211,9 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         address account_
     ) external view override returns (uint128, uint128, uint256) {
         return (
-            _quadraticVoters[distributionId_][account_].votingPower,
-            _quadraticVoters[distributionId_][account_].remainingVotingPower,
-            _quadraticVoters[distributionId_][account_].votesCast.length
+            _voterInfo[distributionId_][account_].fundingVotingPower,
+            _voterInfo[distributionId_][account_].fundingRemainingVotingPower,
+            _voterInfo[distributionId_][account_].votesCast.length
         );
     }
 
@@ -1212,11 +1223,11 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         address account_
     ) external view override returns (uint256 votes_) {
         DistributionPeriod memory currentDistribution = _distributions[distributionId_];
-        QuadraticVoter        memory voter               = _quadraticVoters[currentDistribution.id][account_];
+        VoterInfo        memory voter               = _voterInfo[currentDistribution.id][account_];
 
         uint256 screeningStageEndBlock = _getScreeningStageEndBlock(currentDistribution.startBlock);
 
-        votes_ = _getVotesFunding(account_, voter.votingPower, voter.remainingVotingPower, screeningStageEndBlock);
+        votes_ = _getVotesFunding(account_, voter.fundingVotingPower, voter.fundingRemainingVotingPower, screeningStageEndBlock);
     }
 
     /// @inheritdoc IGrantFundActions

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -833,9 +833,9 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
 
         // check that the voter has enough voting power to cast the vote
         VoterInfo storage voter = _voterInfo[distributionId][msg.sender];
-        // uint256 pastScreeningVotesCast = screeningVotesCast[distributionId][msg.sender];
+        uint248 pastScreeningVotesCast = voter.screeningVotesCast;
         if (
-            uint256(voter.screeningVotesCast) + votes_ > _getVotesScreening(distributionId, msg.sender)
+            pastScreeningVotesCast + votes_ > _getVotesScreening(distributionId, msg.sender)
         ) revert InsufficientVotingPower();
 
         uint256[] storage currentTopTenProposals = _topTenProposals[distributionId];
@@ -874,7 +874,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
 
         // record voters vote
         // screeningVotesCast[distributionId][msg.sender] = pastScreeningVotesCast + votes_;
-        voter.screeningVotesCast += SafeCast.toUint248(votes_);
+        voter.screeningVotesCast = pastScreeningVotesCast + SafeCast.toUint248(votes_);
 
         // emit VoteCast instead of VoteCastWithParams to maintain compatibility with Tally
         emit VoteCast(

--- a/src/grants/base/Storage.sol
+++ b/src/grants/base/Storage.sol
@@ -88,28 +88,16 @@ abstract contract Storage is IGrantFundState {
     mapping(bytes32 slateHash => uint256[] fundedProposalSlate) internal _fundedProposalSlates;
 
     /**
-     * @notice Mapping of distribution periods to voters to a Quadratic Voter info struct.
-     * @dev distributionId => voter address => QuadraticVoter 
-     */
-    mapping(uint256 distributionId => mapping(address voter => QuadraticVoter)) internal _quadraticVoters;
-
-    /**
      * @notice Mapping of distributionId to whether surplus funds from distribution updated into treasury
      * @dev distributionId => bool
     */
     mapping(uint256 distributionId => bool isUpdated) internal _isSurplusFundsUpdated;
 
     /**
-     * @notice Mapping of distributionId to user address to whether user has claimed their delegate reward
-     * @dev distributionId => address => bool
+     * @notice Mapping of distributionId to user address to a VoterInfo struct.
+     * @dev distributionId => address => VoterInfo
     */
-    mapping(uint256 distributionId => mapping(address voter => bool claimed)) public hasClaimedReward;
-
-    /**
-     * @notice Mapping of distributionId to user address to total votes cast on screening stage proposals.
-     * @dev distributionId => address => uint256
-    */
-    mapping(uint256 distributionId => mapping(address voter => uint256 votersScreeningVotesCast)) public screeningVotesCast;
+    mapping(uint256 distributionId => mapping(address voter => VoterInfo)) public _voterInfo;
 
     /**
      * @notice Total funds available for distribution.

--- a/src/grants/interfaces/IGrantFundActions.sol
+++ b/src/grants/interfaces/IGrantFundActions.sol
@@ -218,6 +218,14 @@ interface IGrantFundActions is IGrantFundState {
     function getFundingVotesCast(uint24 distributionId_, address account_) external view returns (FundingVoteParams[] memory);
 
     /**
+     * @notice Get the reward claim status of an account in a given distribution period.
+     * @param  distributionId_ The distributionId of the distribution period to check.
+     * @param  account_        The address of the voter to check.
+     * @return                 The reward claim status of the account in the distribution period.
+     */
+    function getHasClaimedRewards(uint256 distributionId_, address account_) external view returns (bool);
+
+    /**
      * @notice Mapping of proposalIds to {Proposal} structs.
      * @param  proposalId_          The proposalId to retrieve the Proposal struct for.
      * @return proposalId           The retrieved struct's proposalId.
@@ -237,6 +245,14 @@ interface IGrantFundActions is IGrantFundState {
      * @return The block number at which this distribution period's screening stage ends.
     */
     function getScreeningStageEndBlock(uint256 startBlock_) external pure returns (uint256);
+
+    /**
+     * @notice Get the number of screening votes cast by an account in a given distribution period.
+     * @param  distributionId_ The distributionId of the distribution period to check.
+     * @param  account_        The address of the voter to check.
+     * @return                 The number of screening votes successfully cast the voter.
+     */
+    function getScreeningVotesCast(uint256 distributionId_, address account_) external view returns (uint256);
 
     /**
      * @notice Generate a unique hash of a list of proposal Ids for usage as a key for comparing proposal slates.

--- a/src/grants/interfaces/IGrantFundState.sol
+++ b/src/grants/interfaces/IGrantFundState.sol
@@ -101,14 +101,18 @@ interface IGrantFundState {
     /**
      * @notice Contains information about voters during a distribution period's funding stage.
      * @dev    Used in `fundingVote()`, and `claimDelegateReward()`.
-     * @param votingPower           Amount of votes originally available to the voter, equal to the sum of the square of their initial votes.
-     * @param remainingVotingPower  Remaining voting power in the given period.
-     * @param votesCast             Array of votes cast by the voter.
+     * @param fundingVotingPower          Amount of votes originally available to the voter, equal to the sum of the square of their initial votes.
+     * @param fundingRemainingVotingPower Remaining voting power in the given period.
+     * @param votesCast                   Array of votes cast by the voter.
+     * @param screeningVotesCast          Number of screening votes cast by the voter.
+     * @param hasClaimedReward            Whether the voter has claimed their reward for the given period.
      */
-    struct QuadraticVoter {
-        uint128 votingPower;
-        uint128 remainingVotingPower;
+    struct VoterInfo {
+        uint128 fundingVotingPower;
+        uint128 fundingRemainingVotingPower;
         FundingVoteParams[] votesCast;
+        uint248 screeningVotesCast;
+        bool hasClaimedReward;
     }
 
 }

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -560,7 +560,7 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         TestProposal[] memory testProposals = _createNProposals(_grantFund, _token, testProposalParams);
 
         // ensure that user has not voted
-        uint256 screeningVotesCast = _grantFund.screeningVotesCast(distributionId, _tokenHolder1);
+        uint256 screeningVotesCast = _grantFund.getScreeningVotesCast(distributionId, _tokenHolder1);
         assertEq(screeningVotesCast, 0);
 
         // check revert if attempts to vote with 0 power
@@ -580,12 +580,12 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         _screeningVote(_grantFund, screeningVoteParams, _tokenHolder1);
 
         // check that user has voted
-        screeningVotesCast = _grantFund.screeningVotesCast(distributionId, _tokenHolder1);
+        screeningVotesCast = _grantFund.getScreeningVotesCast(distributionId, _tokenHolder1);
         assertEq(screeningVotesCast, 20_000_000 * 1e18);
 
         _screeningVote(_grantFund, _tokenHolder2, testProposals[1].proposalId, 5_000_000 * 1e18);
 
-        screeningVotesCast = _grantFund.screeningVotesCast(distributionId, _tokenHolder2);
+        screeningVotesCast = _grantFund.getScreeningVotesCast(distributionId, _tokenHolder2);
         assertEq(screeningVotesCast, 5_000_000 * 1e18);
 
         changePrank(_tokenHolder1);

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -280,6 +280,45 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         _fundingVoteNoLog(_grantFund, _tokenHolder1, proposal.proposalId, 16_000_000 * 1e18);
     }
 
+    function testVotingPowerAtDistributionStart() external {
+        // 14 tokenholders self delegate their tokens to enable voting on the proposals
+        _selfDelegateVoters(_token, _votersArr);
+
+        // roll 32 blocks forward to the block before the distribution period starts
+        vm.roll(_startBlock + 32);
+
+        // _tokenHolder1 transfers their tokens away
+        address nonVotingAddress = makeAddr("nonVotingAddress");
+        changePrank(_tokenHolder1);
+        _token.transfer(nonVotingAddress, 25_000_000 * 1e18);
+
+        vm.roll(_startBlock + 33);
+
+        // nonVotingAddress returns the funds one block later
+        changePrank(nonVotingAddress);
+        _token.transfer(_tokenHolder1, 25_000_000 * 1e18);
+
+        // start distribution period
+        _startDistributionPeriod(_grantFund);
+
+        // check voting power of _tokenHolder1 is 0
+        uint256 votingPower = _getScreeningVotes(_grantFund, _tokenHolder1);
+        assertEq(votingPower, 0);
+        votingPower = _getScreeningVotes(_grantFund, nonVotingAddress);
+        assertEq(votingPower, 0);
+        votingPower = _getScreeningVotes(_grantFund, _tokenHolder2);
+        assertEq(votingPower, 25_000_000 * 1e18);
+
+        // tokenHolder1 still has no voting power since they didn't keep their tokens for the entire snapshot period
+        vm.roll(_startBlock + 34);
+        votingPower = _getScreeningVotes(_grantFund, _tokenHolder1);
+        assertEq(votingPower, 0);
+
+        vm.roll(_startBlock + 35);
+        votingPower = _getScreeningVotes(_grantFund, _tokenHolder1);
+        assertEq(votingPower, 0);
+    }
+
     function testPropose() external {
         // generate proposal calldata
         bytes[] memory proposalCalldata = new bytes[](1);


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Create a new struct `VoterInfo` that contains the previous `QuadraticVoter` struct, and replaces two mappings. 
  * Stylistically this is a bit cleaner.
  * In terms of gas, there are massive gas savings in `claimDelegateReward` and modest gas savings in `fundingVote`, and `screeningVote.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Gas usage
## Pre Change
```
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |                                                                                                             
|---------------------------------------------|-----------------|--------|--------|--------|---------|                                                                                                             
| Deployment Cost                             | Deployment Size |        |        |        |         |                                                                                                             
| 3170735                                     | 15844           |        |        |        |         |                                                                                                             
| Function Name                               | min             | avg    | median | max    | # calls |                                                                                                             
| claimDelegateReward                         | 645             | 55999  | 57965  | 67542  | 237     |                                                                                                             
| execute                                     | 8590            | 33477  | 37482  | 47082  | 11      |                                                                                                             
| fundTreasury                                | 8096            | 41975  | 44736  | 65683  | 27      |                                                                                                             
| fundingVote                                 | 1209            | 106985 | 107229 | 415068 | 257     |                                                                                                             
| getDelegateReward                           | 2553            | 2570   | 2566   | 2589   | 8       |                                                                                                             
| getDescriptionHash                          | 890             | 909    | 926    | 926    | 113     |                                                                                                             
| getDistributionId                           | 435             | 495    | 435    | 2435   | 656     |                                                                                                             
| getDistributionPeriodInfo                   | 1088            | 1700   | 1088   | 5088   | 124     |                                                                                                             
| getFundedProposalSlate                      | 1154            | 1242   | 1154   | 1389   | 8       |                                                                                                             
| getFundingVotesCast                         | 1601            | 2341   | 2341   | 3081   | 2       |                                                                                                             
| getProposalInfo                             | 1000            | 1000   | 1000   | 1000   | 123     |                                                                                                             
| getSlateHash                                | 911             | 919    | 923    | 923    | 3       |                                                                                                             
| getStage                                    | 1485            | 2314   | 1591   | 9591   | 21      |                                                                                                             
| getTopTenProposals                          | 1187            | 2245   | 2363   | 3304   | 22      |                                                                                                             
| getVoterInfo                                | 1034            | 1034   | 1034   | 1034   | 226     |                                                                                                             
| getVotesFunding                             | 2439            | 6625   | 2847   | 11954  | 15      |                                                                                                             
| getVotesScreening                           | 5218            | 5234   | 5218   | 6124   | 490     |                                                                                                             
| hashProposal                                | 4029            | 4029   | 4029   | 4029   | 102     |                                                                                                             
| propose                                     | 2936            | 78314  | 82561  | 83577  | 114     |                                                                                                             
| screeningVote                               | 1052            | 45172  | 37234  | 395508 | 277     |                                                                                                             
| screeningVotesCast                          | 675             | 1341   | 675    | 2675   | 3       |                                                                                                             
| startNewDistributionPeriod                  | 571             | 36240  | 35927  | 51971  | 30      |                                                                                                             
| state                                       | 1131            | 1981   | 2384   | 2756   | 10      |                                                                                                             
| treasury                                    | 396             | 396    | 396    | 396    | 8       |                                                                                                             
| updateSlate                                 | 1160            | 56689  | 69669  | 309978 | 21      |   
```

## Post Change
```
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |                                                                                                             
|---------------------------------------------|-----------------|--------|--------|--------|---------|                                                                                                             
| Deployment Cost                             | Deployment Size |        |        |        |         |                                                                                                             
| 3245430                                     | 16217           |        |        |        |         |                                                                                                             
| Function Name                               | min             | avg    | median | max    | # calls |                                                                                                             
| claimDelegateReward                         | 739             | 34663  | 35831  | 45408  | 285     |                                                                                                             
| execute                                     | 8575            | 33462  | 37467  | 47067  | 11      |                                                                                                             
| fundTreasury                                | 8096            | 41975  | 44736  | 65683  | 27      |                                                                                                             
| fundingVote                                 | 1187            | 105669 | 105600 | 413630 | 305     |                                                                                                             
| getDelegateReward                           | 2553            | 2570   | 2566   | 2589   | 8       |                                                                                                             
| getDescriptionHash                          | 890             | 922    | 926    | 926    | 69      |                                                                                                             
| getDistributionId                           | 435             | 491    | 435    | 2435   | 708     |                                                                                                             
| getDistributionPeriodInfo                   | 1088            | 2038   | 1088   | 5088   | 80      |                                                                                                             
| getFundedProposalSlate                      | 1132            | 1220   | 1132   | 1367   | 8       |                                                                                                             
| getFundingVotesCast                         | 1579            | 2319   | 2319   | 3059   | 2       |                                                                                                             
| getProposalInfo                             | 978             | 978    | 978    | 978    | 116     |                                                                                                             
| getScreeningVotesCast                       | 765             | 1431   | 765    | 2765   | 3       |                                                                                                             
| getSlateHash                                | 889             | 897    | 901    | 901    | 3       |                                                                                                             
| getStage                                    | 1485            | 2314   | 1591   | 9591   | 21      |                                                                                                             
| getTopTenProposals                          | 1187            | 2170   | 2363   | 3304   | 22      |                                                                                                             
| getVoterInfo                                | 1012            | 1012   | 1012   | 1012   | 274     |                                                                                                             
| getVotesFunding                             | 2647            | 7100   | 3056   | 14162  | 15      |                                                                                                             
| getVotesScreening                           | 5285            | 5298   | 5285   | 6191   | 586     |                                                                                                             
| hashProposal                                | 4014            | 4014   | 4014   | 4014   | 58      |                                                                                                             
| propose                                     | 2914            | 75636  | 83569  | 83569  | 70      |                                                                                                             
| screeningVote                               | 1099            | 39141  | 35082  | 394918 | 325     |                                                                                                             
| startNewDistributionPeriod                  | 571             | 36240  | 35927  | 51971  | 30      |                                                                                                             
| state                                       | 1109            | 1959   | 2362   | 2734   | 10      |                                                                                                             
| treasury                                    | 374             | 374    | 374    | 374    | 8       |                                                                                                             
| updateSlate                                 | 1138            | 47598  | 69647  | 119493 | 21      | 
```

