### PR TITLE
Add invariants DP7, SS10, SS11, ES4, ES5 and DR4

### DIFF
--- a/test/invariants/INVARIANTS.md
+++ b/test/invariants/INVARIANTS.md
@@ -27,7 +27,7 @@
     - **SS8**: A proposal can only receive screening votes if it was created via `propose()`.
     - **SS9**: A proposal can only be created during a distribution period's screening stage.
     - **SS10**: A proposal's proposalId must be unique.
-    - **SS11**: A proposal's tokens requested must be <= GBC>.
+    - **SS11**: A proposal's tokens requested must be <= 90% of GBC.
 
 - #### Funding Stage:
     - **FS1**: Only 10 proposals can be voted on in the funding stage
@@ -52,7 +52,7 @@
     - **ES2**: A proposal can only be executed after the challenge stage is complete.
     - **ES3**: A proposal can only be executed once.
     - **ES4**: A proposal can only be executed if it was in the top ten screened proposals at the end of the screening stage.
-    - **ES5**: An executed proposal should only ever transfer tokens <= GBC.
+    - **ES5**: An executed proposal should only ever transfer tokens <= 90% of GBC.
 
 - #### Delegation Rewards:
     - **DR1**: Cumulative delegation rewards should be <= 10% of a distribution periods GBC.

--- a/test/invariants/StandardFinalizeInvariant.t.sol
+++ b/test/invariants/StandardFinalizeInvariant.t.sol
@@ -135,14 +135,6 @@ contract StandardFinalizeInvariant is StandardTestBase {
 
             uint256[] memory topSlateProposalIds = _grantFund.getFundedProposalSlate(topSlateHash);
 
-            // calculate the total tokens requested by the proposals in the top slate
-            uint256 totalTokensRequested = 0;
-            for (uint256 i = 0; i < topSlateProposalIds.length; ++i) {
-                uint256 proposalId = topSlateProposalIds[i];
-                (, , , uint128 tokensRequested, , ) = _grantFund.getProposalInfo(proposalId);
-                totalTokensRequested += tokensRequested;
-            }
-
             uint256[] memory standardFundingProposals = _standardHandler.getStandardFundingProposals(distributionId);
             uint256[] memory topTenScreenedProposalIds = _grantFund.getTopTenProposals(distributionId);
 

--- a/test/invariants/StandardFinalizeInvariant.t.sol
+++ b/test/invariants/StandardFinalizeInvariant.t.sol
@@ -15,6 +15,12 @@ import { Handler }          from "./handlers/Handler.sol";
 
 contract StandardFinalizeInvariant is StandardTestBase {
 
+    struct LocalVotersInfo {
+        uint128 fundingVotingPower;
+        uint128 fundingRemainingVotingPower;
+        uint256 votesCast;
+    }
+
     // override setup to start tests in the challenge stage with proposals that have already been screened and funded
     function setUp() public override {
         super.setUp();
@@ -113,111 +119,140 @@ contract StandardFinalizeInvariant is StandardTestBase {
         }
     }
 
-    function invariant_ES1_ES2_ES3() external {
+    function invariant_ES1_ES2_ES3_ES4_ES5() external {
         uint24 distributionId = _grantFund.getDistributionId();
-        (, , , , , bytes32 topSlateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
+        while (distributionId > 0) {
+            (, , , uint256 gbc, , bytes32 topSlateHash) = _grantFund.getDistributionPeriodInfo(distributionId);
 
-        uint256[] memory topSlateProposalIds = _grantFund.getFundedProposalSlate(topSlateHash);
+            uint256[] memory topSlateProposalIds = _grantFund.getFundedProposalSlate(topSlateHash);
 
-        // calculate the total tokens requested by the proposals in the top slate
-        uint256 totalTokensRequested = 0;
-        for (uint256 i = 0; i < topSlateProposalIds.length; ++i) {
-            uint256 proposalId = topSlateProposalIds[i];
-            (, , , uint128 tokensRequested, , ) = _grantFund.getProposalInfo(proposalId);
-            totalTokensRequested += tokensRequested;
-        }
-
-        uint256[] memory standardFundingProposals = _standardHandler.getStandardFundingProposals(distributionId);
-
-        // check the state of every proposal submitted in this distribution period
-        for (uint256 i = 0; i < standardFundingProposals.length; ++i) {
-            uint256 proposalId = standardFundingProposals[i];
-            (, uint24 proposalDistributionId, , , , bool executed) = _grantFund.getProposalInfo(proposalId);
-            int256 proposalIndex = _findProposalIndex(proposalId, topSlateProposalIds);
-            // invariant ES1: A proposal can only be executed if it's listed in the final funded proposal slate at the end of the challenge round.
-            if (proposalIndex == -1) {
-                assertFalse(executed);
+            // calculate the total tokens requested by the proposals in the top slate
+            uint256 totalTokensRequested = 0;
+            for (uint256 i = 0; i < topSlateProposalIds.length; ++i) {
+                uint256 proposalId = topSlateProposalIds[i];
+                (, , , uint128 tokensRequested, , ) = _grantFund.getProposalInfo(proposalId);
+                totalTokensRequested += tokensRequested;
             }
 
-            // invariant ES2: A proposal can only be executed if it's listed in the final funded proposal slate at the end of the challenge round.
-            assertEq(distributionId, proposalDistributionId);
-            if (executed) {
-                (, , uint48 endBlock, , , ) = _grantFund.getDistributionPeriodInfo(proposalDistributionId);
-                // TODO: store and check proposal execution time
-                require(
-                    currentBlock > endBlock,
-                    "invariant ES2: A proposal can only be executed after the challenge stage is complete."
-                );
-            }
-        }
+            uint256[] memory standardFundingProposals = _standardHandler.getStandardFundingProposals(distributionId);
+            uint256[] memory topTenScreenedProposalIds = _grantFund.getTopTenProposals(distributionId);
 
-        require(
-            !_standardHandler.hasDuplicates(_standardHandler.getProposalsExecuted()),
-            "invariant ES3: A proposal can only be executed once."
-        );
-    }
-
-    function invariant_DR1_DR2_DR3_DR5() external {
-        uint24 distributionId = _grantFund.getDistributionId();
-        (, , , uint128 fundsAvailable, uint256 fundingVotePowerCast, ) = _grantFund.getDistributionPeriodInfo(distributionId);
-
-        uint256 totalRewardsClaimed;
-
-        for (uint256 i = 0; i < _standardHandler.getActorsCount(); ++i) {
-            address actor = _standardHandler.actors(i);
-
-            // get the initial funding stage voting power of the actor
-            (uint128 votingPower, uint128 remainingVotingPower, ) = _grantFund.getVoterInfo(distributionId, actor);
-
-            // get actor info from standard handler
-            (
-                IGrantFund.FundingVoteParams[] memory fundingVoteParams,
-                IGrantFund.ScreeningVoteParams[] memory screeningVoteParams,
-                uint256 delegationRewardsClaimed
-            ) = _standardHandler.getVotingActorsInfo(actor, distributionId);
-
-            totalRewardsClaimed += delegationRewardsClaimed;
-
-            if (delegationRewardsClaimed != 0) {
-                // check that delegation rewards are greater tahn 0 if they did vote in both stages
-                assertTrue(delegationRewardsClaimed >= 0);
-
-                uint256 votingPowerAllocatedByDelegatee = votingPower - remainingVotingPower;
-                uint256 rootVotingPowerAllocatedByDelegatee = Math.sqrt(votingPowerAllocatedByDelegatee * 1e18);
-
-                require(
-                    fundingVoteParams.length > 0 && screeningVoteParams.length > 0,
-                    "invariant DR2: Delegation rewards are 0 if voter didn't vote in both stages."
-                );
-
-                uint256 rewards;
-                if (votingPowerAllocatedByDelegatee > 0) {
-                    rewards = Math.mulDiv(
-                        fundsAvailable,
-                        rootVotingPowerAllocatedByDelegatee,
-                        10 * fundingVotePowerCast
-                    );
+            // check the state of every proposal submitted in this distribution period
+            for (uint256 i = 0; i < standardFundingProposals.length; ++i) {
+                uint256 proposalId = standardFundingProposals[i];
+                (, uint24 proposalDistributionId, , uint256 tokenRequested, , bool executed) = _grantFund.getProposalInfo(proposalId);
+                int256 proposalIndex = _findProposalIndex(proposalId, topSlateProposalIds);
+                // invariant ES1: A proposal can only be executed if it's listed in the final funded proposal slate at the end of the challenge round.
+                if (proposalIndex == -1) {
+                    assertFalse(executed);
                 }
 
-                require(
-                    delegationRewardsClaimed == rewards,
-                    "invariant DR3: Delegation rewards are proportional to voters funding power allocated in the funding stage."
-                );
+                // invariant ES2: A proposal can only be executed after the challenge stage is complete.
+                assertEq(distributionId, proposalDistributionId);
+                if (executed) {
+                    (, , uint48 endBlock, , , ) = _grantFund.getDistributionPeriodInfo(proposalDistributionId);
+                    // TODO: store and check proposal execution time
+                    require(
+                        currentBlock > endBlock,
+                        "invariant ES2: A proposal can only be executed after the challenge stage is complete."
+                    );
+
+                    // check if proposalId exist in topTenScreenedProposals if it is executed
+                    require(
+                        _findProposalIndex(proposalId, topTenScreenedProposalIds) != -1,
+                        "invariant ES4: A proposal can only be executed if it was in the top ten screened proposals at the end of the screening stage."
+                    );
+
+                    require(
+                        tokenRequested <= gbc * 9 / 10,
+                        "invariant ES5: An executed proposal should only ever transfer tokens <= 90% of GBC"
+                    );
+
+                }
             }
-        }
 
-        require(
-            totalRewardsClaimed <= fundsAvailable * 1 / 10,
-            "invariant DR1: Cumulative delegation rewards should be <= 10% of a distribution periods GBC"
-        );
-
-        // check state after all possible delegation rewards have been claimed
-        if (_standardHandler.numberOfCalls('SFH.claimDelegateReward.success') == _standardHandler.getActorsCount()) {
             require(
-                totalRewardsClaimed >= Maths.wmul(fundsAvailable * 1 / 10, 0.9999 * 1e18),
-                "invariant DR5: Cumulative rewards claimed should be within 99.99% -or- 0.01 AJNA tokens of all available delegation rewards"
+                !_standardHandler.hasDuplicates(_standardHandler.getProposalsExecuted()),
+                "invariant ES3: A proposal can only be executed once."
             );
-            assertEq(totalRewardsClaimed, fundsAvailable * 1 / 10);
+
+            --distributionId;
+        }
+    }
+
+    function invariant_DR1_DR2_DR3_DR4_DR5() external {
+        uint24 distributionId = _grantFund.getDistributionId();
+        while (distributionId > 0) {
+            (, , uint256 distributionEndBlock, uint128 fundsAvailable, uint256 fundingVotePowerCast, ) = _grantFund.getDistributionPeriodInfo(distributionId);
+
+            uint256 totalRewardsClaimed;
+
+            for (uint256 i = 0; i < _standardHandler.getActorsCount(); ++i) {
+                address actor = _standardHandler.actors(i);
+
+                // get the initial funding stage voting power of the actor
+                LocalVotersInfo memory votersInfo;
+               (votersInfo.fundingVotingPower, votersInfo.fundingRemainingVotingPower, ) = _grantFund.getVoterInfo(distributionId, actor);
+
+                // get actor info from standard handler
+                (
+                    IGrantFund.FundingVoteParams[] memory fundingVoteParams,
+                    IGrantFund.ScreeningVoteParams[] memory screeningVoteParams,
+                    uint256 delegationRewardsClaimed
+                ) = _standardHandler.getVotingActorsInfo(actor, distributionId);
+
+                totalRewardsClaimed += delegationRewardsClaimed;
+
+                if (delegationRewardsClaimed != 0) {
+                    // check that delegation rewards are greater tahn 0 if they did vote in both stages
+                    assertTrue(delegationRewardsClaimed >= 0);
+
+                    uint256 votingPowerAllocatedByDelegatee = votersInfo.fundingVotingPower - votersInfo.fundingRemainingVotingPower;
+                    uint256 rootVotingPowerAllocatedByDelegatee = Math.sqrt(votingPowerAllocatedByDelegatee * 1e18);
+
+                    require(
+                        fundingVoteParams.length > 0 && screeningVoteParams.length > 0,
+                        "invariant DR2: Delegation rewards are 0 if voter didn't vote in both stages."
+                    );
+
+                    uint256 rewards;
+                    if (votingPowerAllocatedByDelegatee > 0) {
+                        rewards = Math.mulDiv(
+                            fundsAvailable,
+                            rootVotingPowerAllocatedByDelegatee,
+                            10 * fundingVotePowerCast
+                        );
+                    }
+
+                    require(
+                        delegationRewardsClaimed == rewards,
+                        "invariant DR3: Delegation rewards are proportional to voters funding power allocated in the funding stage."
+                    );
+
+                    if (distributionEndBlock >= block.timestamp) {
+                        require(
+                            _grantFund.getHasClaimedRewards(distributionId, actor) == false,
+                            "invariant DR4: Delegation rewards can only be claimed for a distribution period after it ended"
+                        );
+                    }
+                }
+            }
+
+            require(
+                totalRewardsClaimed <= fundsAvailable * 1 / 10,
+                "invariant DR1: Cumulative delegation rewards should be <= 10% of a distribution periods GBC"
+            );
+
+            // check state after all possible delegation rewards have been claimed
+            if (_standardHandler.numberOfCalls('SFH.claimDelegateReward.success') == _standardHandler.getActorsCount()) {
+                require(
+                    totalRewardsClaimed >= Maths.wmul(fundsAvailable * 1 / 10, 0.9999 * 1e18),
+                    "invariant DR5: Cumulative rewards claimed should be within 99.99% -or- 0.01 AJNA tokens of all available delegation rewards"
+                );
+                assertEq(totalRewardsClaimed, fundsAvailable * 1 / 10);
+            }
+
+            --distributionId;
         }
     }
 

--- a/test/invariants/StandardMultipleDistributionInvariant.t.sol
+++ b/test/invariants/StandardMultipleDistributionInvariant.t.sol
@@ -122,15 +122,10 @@ contract StandardMultipleDistributionInvariant is StandardTestBase {
         }
     }
 
-    function invariant_DP6() external {
+    function invariant_DP6_DP7() external {
         uint24 distributionId = _grantFund.getDistributionId();
 
-        for (uint24 i = 0; i <= distributionId; ) {
-            if (i == 0) {
-                ++i;
-                continue;
-            }
-
+        for (uint24 i = 1; i <= distributionId; ) {
             (
                 ,
                 ,

--- a/test/invariants/StandardScreeningInvariant.t.sol
+++ b/test/invariants/StandardScreeningInvariant.t.sol
@@ -106,13 +106,13 @@ contract StandardScreeningInvariant is StandardTestBase {
 
             // check proposalId is unique
             require(
-                _checkDuplicate(proposalIds) == false, "invariant SS10: A proposal's proposalId must be unique"
+                !hasDuplicates(proposalIds), "invariant SS10: A proposal's proposalId must be unique"
             );
 
             // Add current proposal Id to proposalIds set
             proposalIds[j] = proposalId;
 
-            require (
+            require(
                 tokensRequested <= gbc * 9 / 10, "invariant SS11: A proposal's tokens requested must be <= 90% of GBC"
             );
         }

--- a/test/invariants/base/StandardTestBase.sol
+++ b/test/invariants/base/StandardTestBase.sol
@@ -36,4 +36,19 @@ contract StandardTestBase is TestBase {
         currentBlock = block.number;
         _grantFund.startNewDistributionPeriod();
     }
+
+    /******************************/
+    /******* Helper Functions ****/
+    /*****************************/
+
+    function _checkDuplicate(uint256[] memory arr) internal pure returns(bool) {
+        for (uint i = 0; i < arr.length; ++i) {
+            for (uint j = i + 1; j < arr.length; ++j) {
+                if (arr[i] != 0 && arr[i] == arr[j]) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/test/invariants/base/StandardTestBase.sol
+++ b/test/invariants/base/StandardTestBase.sol
@@ -36,19 +36,4 @@ contract StandardTestBase is TestBase {
         currentBlock = block.number;
         _grantFund.startNewDistributionPeriod();
     }
-
-    /******************************/
-    /******* Helper Functions ****/
-    /*****************************/
-
-    function _checkDuplicate(uint256[] memory arr) internal pure returns(bool) {
-        for (uint i = 0; i < arr.length; ++i) {
-            for (uint j = i + 1; j < arr.length; ++j) {
-                if (arr[i] != 0 && arr[i] == arr[j]) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
 }


### PR DESCRIPTION
# Description of change
## High level
* Implemented invariants:
  * DP7: A distribution period's surplus should only be readded to the treasury once.
  * DR4: Delegation rewards can only be claimed for a distribution period after it ended.
  * ES4: A proposal can only be executed if it was in the top ten screened proposals at the end of the screening stage.
  * ES5: An executed proposal should only ever transfer tokens <= 90% of GBC.
  * SS10: A proposal's proposalId must be unique.
  * SS11: A proposal's tokens requested must be <= 90% of GBC.
