### PR TITLE
0 input validation in getDelegateReward

### DIFF
--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -235,6 +235,10 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
     ) internal view returns (uint256 rewards_) {
         // calculate the total voting power available to the voter that was allocated in the funding stage
         uint256 votingPowerAllocatedByDelegatee = voter_.fundingVotingPower - voter_.fundingRemainingVotingPower;
+
+        // check for inputs that would revert with divide by 0
+        if (votingPowerAllocatedByDelegatee == 0 || currentDistribution_.fundsAvailable == 0 || currentDistribution_.fundingVotePowerCast == 0) return 0;
+
         // take the sqrt of the voting power allocated to compare against the root of all voting power allocated
         // multiply by 1e18 to maintain WAD precision
         uint256 rootVotingPowerAllocatedByDelegatee = Math.sqrt(votingPowerAllocatedByDelegatee * 1e18);

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -243,16 +243,13 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         // multiply by 1e18 to maintain WAD precision
         uint256 rootVotingPowerAllocatedByDelegatee = Math.sqrt(votingPowerAllocatedByDelegatee * 1e18);
 
-        // if none of the voter's voting power was allocated, they receive no rewards
-        if (rootVotingPowerAllocatedByDelegatee != 0) {
-            // calculate reward
-            // delegateeReward = 10 % of GBC distributed as per delegatee Voting power allocated
-            rewards_ = Math.mulDiv(
-                currentDistribution_.fundsAvailable,
-                rootVotingPowerAllocatedByDelegatee,
-                10 * currentDistribution_.fundingVotePowerCast
-            );
-        }
+        // calculate reward
+        // delegateeReward = 10 % of GBC distributed as per delegatee Voting power allocated
+        rewards_ = Math.mulDiv(
+            currentDistribution_.fundsAvailable,
+            rootVotingPowerAllocatedByDelegatee,
+            10 * currentDistribution_.fundingVotePowerCast
+        );
     }
 
     /***********************************/

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -225,6 +225,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
     /**
      * @notice Calculate the delegate rewards that have accrued to a given voter, in a given distribution period.
      * @dev    Voter must have voted in both the screening and funding stages, and is proportional to their share of votes across the stages.
+     * @dev    If the provided distribution period hasn't passed the end of the funding stage, or the voter's funding votes were 0 then calculated rewards will be 0.
      * @param  currentDistribution_ Struct of the distribution period to calculate rewards for.
      * @param  voter_               Struct of the funding stages voter.
      * @return rewards_             The delegate rewards accrued to the voter.
@@ -236,20 +237,24 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         // calculate the total voting power available to the voter that was allocated in the funding stage
         uint256 votingPowerAllocatedByDelegatee = voter_.fundingVotingPower - voter_.fundingRemainingVotingPower;
 
-        // check for inputs that would revert with divide by 0
-        if (votingPowerAllocatedByDelegatee == 0 || currentDistribution_.fundsAvailable == 0 || currentDistribution_.fundingVotePowerCast == 0) return 0;
+        if (votingPowerAllocatedByDelegatee != 0) {
+            uint256 fundsAvailable       = currentDistribution_.fundsAvailable;
+            uint256 fundingVotePowerCast = currentDistribution_.fundingVotePowerCast;
 
-        // take the sqrt of the voting power allocated to compare against the root of all voting power allocated
-        // multiply by 1e18 to maintain WAD precision
-        uint256 rootVotingPowerAllocatedByDelegatee = Math.sqrt(votingPowerAllocatedByDelegatee * 1e18);
+            if (fundsAvailable != 0 && fundingVotePowerCast != 0) {
+                // take the sqrt of the voting power allocated to compare against the root of all voting power allocated
+                // multiply by 1e18 to maintain WAD precision
+                uint256 rootVotingPowerAllocatedByDelegatee = Math.sqrt(votingPowerAllocatedByDelegatee * 1e18);
 
-        // calculate reward
-        // delegateeReward = 10 % of GBC distributed as per delegatee Voting power allocated
-        rewards_ = Math.mulDiv(
-            currentDistribution_.fundsAvailable,
-            rootVotingPowerAllocatedByDelegatee,
-            10 * currentDistribution_.fundingVotePowerCast
-        );
+                // calculate reward
+                // delegateeReward = 10 % of GBC distributed as per delegatee Voting power allocated
+                rewards_ = Math.mulDiv(
+                    fundsAvailable,
+                    rootVotingPowerAllocatedByDelegatee,
+                    10 * fundingVotePowerCast
+                );
+            }
+        }
     }
 
     /***********************************/

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -168,6 +168,8 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         vm.roll(endBlock + 1);
         assertEq(_grantFund.getStage(), keccak256(bytes("Pending")));
         // check can now claim delegate rewards
+        uint256 rewards = _grantFund.getDelegateReward(distributionId, _tokenHolder1);
+        assertGt(rewards, 0);
         _claimDelegateReward(_grantFund, _tokenHolder1, distributionId, _grantFund.getDelegateReward(distributionId, _tokenHolder1));
     }
 
@@ -1935,6 +1937,10 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         _token.delegate(lowRewardAddress);
 
         vm.roll(_startBlock + 150);
+
+        // rewards are 0 before distribution period starts
+        uint256 rewards = _grantFund.getDelegateReward(1, _tokenHolder1);
+        assertEq(rewards, 0);
 
         // start distribution period
         _startDistributionPeriod(_grantFund);


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Add 0 input validation to calls to `getDelegateReward`

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Calls to `getDelegateReward` revert with `Divide by 0` in invalid system state.

# Gas usage

Minimal increase in gas used by `claimDelegateReward`.

## Pre Change
```
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |                                                                                                             
|---------------------------------------------|-----------------|--------|--------|--------|---------|                                                                                                             
| Deployment Cost                             | Deployment Size |        |        |        |         |                                                                                                             
| 3238022                                     | 16180           |        |        |        |         |                                                                                                             
| Function Name                               | min             | avg    | median | max    | # calls |                                                                                                             
| claimDelegateReward                         | 739             | 33077  | 35826  | 45408  | 130     |                                                                                                             
| execute                                     | 8575            | 33452  | 37453  | 47053  | 11      |                                                                                                             
| fundTreasury                                | 8096            | 41975  | 44736  | 65683  | 27      |                                                                                                             
| fundingVote                                 | 1187            | 104795 | 106194 | 413550 | 152     |                                                                                                             
| getChallengeStageStartBlock                 | 582             | 582    | 582    | 582    | 1       |                                                                                                             
| getDelegateReward                           | 2553            | 2569   | 2566   | 2589   | 9       |                                                                                                             
| getDescriptionHash                          | 890             | 920    | 926    | 926    | 74      |                                                                                                             
| getDistributionId                           | 435             | 535    | 435    | 2435   | 399     |                                                                                                             
| getDistributionPeriodInfo                   | 1088            | 2029   | 1088   | 5088   | 85      |                                                                                                             
| getFundedProposalSlate                      | 1132            | 1220   | 1132   | 1367   | 8       |                                                                                                             
| getFundingStageEndBlock                     | 517             | 517    | 517    | 517    | 1       |                                                                                                             
| getFundingVotesCast                         | 1579            | 2319   | 2319   | 3059   | 2       |                                                                                                             
| getHasClaimedRewards                        | 721             | 721    | 721    | 721    | 5       |                                                                                                             
| getProposalInfo                             | 978             | 978    | 978    | 978    | 119     |                                                                                                             
| getScreeningStageEndBlock                   | 463             | 463    | 463    | 463    | 1       |                                                                                                             
| getScreeningVotesCast                       | 765             | 1431   | 765    | 2765   | 3       |                                                                                                             
| getSlateHash                                | 889             | 893    | 889    | 901    | 5       |                                                                                                             
| getStage                                    | 1485            | 2123   | 1591   | 9591   | 21      |                                                                                                             
| getTopTenProposals                          | 1187            | 2202   | 2363   | 3304   | 22      |                                                                                                             
| getVoterInfo                                | 1012            | 1012   | 1012   | 1012   | 117     |                                                                                                             
| getVotesFunding                             | 2644            | 7059   | 3053   | 14079  | 15      |                                                                                                             
| getVotesScreening                           | 5285            | 5314   | 5285   | 6191   | 272     |                                                                                                             
| hashProposal                                | 4014            | 4014   | 4014   | 4014   | 63      |                                                                                                             
| propose                                     | 2914            | 76124  | 83569  | 83569  | 75      |                                                                                                             
| screeningVote                               | 1099            | 44228  | 36450  | 394918 | 172     |                                                                                                             
| startNewDistributionPeriod                  | 571             | 36240  | 35927  | 51971  | 30      |                                                                                                             
| state                                       | 1109            | 1959   | 2362   | 2734   | 10      |                                                                                                             
| treasury                                    | 374             | 374    | 374    | 374    | 8       |                                                                                                             
| updateSlate                                 | 1213            | 50079  | 69722  | 198147 | 24      | 
```
## Post Change
```
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |                                                                                                             
|---------------------------------------------|-----------------|--------|--------|--------|---------|                                                                                                             
| Deployment Cost                             | Deployment Size |        |        |        |         |                                                                                                             
| 3238422                                     | 16182           |        |        |        |         |                                                                                                             
| Function Name                               | min             | avg    | median | max    | # calls |                                                                                                             
| claimDelegateReward                         | 739             | 30793  | 35832  | 45414  | 71      |                                                                                                             
| execute                                     | 8575            | 33452  | 37453  | 47053  | 11      |                                                                                                             
| fundTreasury                                | 8096            | 41975  | 44736  | 65683  | 27      |                                                                                                             
| fundingVote                                 | 1187            | 104357 | 106909 | 413550 | 93      |                                                                                                             
| getChallengeStageStartBlock                 | 582             | 582    | 582    | 582    | 1       |                                                                                                             
| getDelegateReward                           | 2559            | 2620   | 2572   | 3074   | 11      |                                                                                                             
| getDescriptionHash                          | 890             | 914    | 926    | 926    | 94      |                                                                                                             
| getDistributionId                           | 435             | 567    | 435    | 2435   | 301     |                                                                                                             
| getDistributionPeriodInfo                   | 1088            | 1849   | 1088   | 5088   | 105     |                                                                                                             
| getFundedProposalSlate                      | 1132            | 1220   | 1132   | 1367   | 8       |                                                                                                             
| getFundingStageEndBlock                     | 517             | 517    | 517    | 517    | 1       |                                                                                                             
| getFundingVotesCast                         | 1579            | 2319   | 2319   | 3059   | 2       |                                                                                                             
| getHasClaimedRewards                        | 721             | 721    | 721    | 721    | 5       |                                                                                                             
| getProposalInfo                             | 978             | 978    | 978    | 978    | 123     |                                                                                                             
| getScreeningStageEndBlock                   | 463             | 463    | 463    | 463    | 1       |                                                                                                             
| getScreeningVotesCast                       | 765             | 1431   | 765    | 2765   | 3       |                                                                                                             
| getSlateHash                                | 889             | 893    | 889    | 901    | 5       |                                                                                                             
| getStage                                    | 1485            | 2123   | 1591   | 9591   | 21      |                                                                                                             
| getTopTenProposals                          | 1187            | 2245   | 2363   | 3304   | 22      |                                                                                                             
| getVoterInfo                                | 1012            | 1012   | 1012   | 1012   | 58      |                                                                                                             
| getVotesFunding                             | 2644            | 7059   | 3053   | 14079  | 15      |                                                                                                             
| getVotesScreening                           | 5285            | 5337   | 5285   | 6191   | 154     |                                                                                                             
| hashProposal                                | 4014            | 4014   | 4014   | 4014   | 83      |                                                                                                             
| propose                                     | 2914            | 77477  | 83569  | 83569  | 95      |                                                                                                             
| screeningVote                               | 1099            | 53133  | 54227  | 394918 | 113     |                                                                                                             
| startNewDistributionPeriod                  | 571             | 36240  | 35927  | 51971  | 30      |                                                                                                             
| state                                       | 1109            | 1959   | 2362   | 2734   | 10      |                                                                                                             
| treasury                                    | 374             | 374    | 374    | 374    | 8       |                                                                                                             
| updateSlate                                 | 1213            | 54741  | 69722  | 310031 | 24      |                                                                                                             
```

