### PR TITLE
Sherlock-79: Burn ajna tokens on wrap

### DIFF
--- a/src/token/BurnWrapper.sol
+++ b/src/token/BurnWrapper.sol
@@ -12,11 +12,11 @@ import { ERC20Wrapper }   from "@oz/token/ERC20/extensions/ERC20Wrapper.sol";
 import { IERC20Metadata } from "@oz/token/ERC20/extensions/IERC20Metadata.sol";
 
 /**
-    * @title Ajna Token `ERC20` token interface.
-    * @dev Ajna Token `ERC20` token interface, including the following functions:
-    * - `burnFrom()`
-    * @dev Used by the `BurnWrappedAjna` contract to burn Ajna tokens on wrapping.
-    */
+ * @title Ajna Token `ERC20` token interface.
+ * @dev Ajna Token `ERC20` token interface, including the following functions:
+ * - `burnFrom()`
+ * @dev Used by the `BurnWrappedAjna` contract to burn Ajna tokens on wrapping.
+*/
 interface IERC20Token {
     function burnFrom(address account, uint256 amount) external;
 }
@@ -26,7 +26,7 @@ interface IERC20Token {
  *  @title  BurnWrappedAjna Contract
  *  @notice Entrypoint of BurnWrappedAjna actions for Ajna token holders looking to migrate their assets to a sidechain:
  *          - `TokenHolders`: Approve the BurnWrappedAjna contract to burn a specified amount of Ajna tokens, and mint them a corresponding amount of BurnWrappedAjna tokens.
- *  @dev    This contract is intended for usage in cases where users are attempting to migrate their Ajna to a sidechain that lacks a permissionless bridge. 
+ *  @dev    This contract is intended for usage in cases where users are attempting to migrate their Ajna to a sidechain that lacks a permissionless bridge.
  *          Usage of this contract protects holders from the risk of a compromised sidechain bridge.
  *  @dev    Contract inherits from OpenZeppelin ERC20Burnable and ERC20Wrapper extensions.
  *  @dev    Only mainnet Ajna token can be wrapped. Tokens that have been wrapped cannot be unwrapped, as they are burned on wrapping.

--- a/src/token/BurnWrapper.sol
+++ b/src/token/BurnWrapper.sol
@@ -11,6 +11,11 @@ import { ERC20Permit }    from "@oz/token/ERC20/extensions/draft-ERC20Permit.sol
 import { ERC20Wrapper }   from "@oz/token/ERC20/extensions/ERC20Wrapper.sol";
 import { IERC20Metadata } from "@oz/token/ERC20/extensions/IERC20Metadata.sol";
 
+/// @dev Ajna Token `ERC20` token interface.
+interface IERC20Token {
+    function burnFrom(address account, uint256 amount) external;
+}
+
 contract BurnWrappedAjna is ERC20, ERC20Burnable, ERC20Permit, ERC20Wrapper {
 
     /**
@@ -48,6 +53,18 @@ contract BurnWrappedAjna is ERC20, ERC20Burnable, ERC20Permit, ERC20Wrapper {
     function decimals() public pure override(ERC20, ERC20Wrapper) returns (uint8) {
         // since the Ajna Token has 18 decimals, we can just return 18 here.
         return 18;
+    }
+
+    /**
+     * @notice Override wrap method to burn Ajna tokens on wrapping instead of transferring to the wrapper contract.
+     */
+    function depositFor(address account, uint256 amount) public override returns (bool) {
+        // burn the existing ajna tokens
+        IERC20Token(AJNA_TOKEN_ADDRESS).burnFrom(account, amount);
+
+        // mint the new wrapped tokens
+        _mint(account, amount);
+        return true;
     }
 
     /**

--- a/src/token/BurnWrapper.sol
+++ b/src/token/BurnWrapper.sol
@@ -24,7 +24,7 @@ interface IERC20Token {
 
 /**
  *  @title  BurnWrappedAjna Contract
- *  @notice Entrypoint of BurnWrappedAjna actions for Ajna token holders looking to migrate their assets to a sidechain:
+ *  @notice Entrypoint of BurnWrappedAjna actions for Ajna token holders looking to migrate their tokens to a sidechain:
  *          - `TokenHolders`: Approve the BurnWrappedAjna contract to burn a specified amount of Ajna tokens, and mint them a corresponding amount of BurnWrappedAjna tokens.
  *  @dev    This contract is intended for usage in cases where users are attempting to migrate their Ajna to a sidechain that lacks a permissionless bridge.
  *          Usage of this contract protects holders from the risk of a compromised sidechain bridge.

--- a/src/token/BurnWrapper.sol
+++ b/src/token/BurnWrapper.sol
@@ -11,11 +11,26 @@ import { ERC20Permit }    from "@oz/token/ERC20/extensions/draft-ERC20Permit.sol
 import { ERC20Wrapper }   from "@oz/token/ERC20/extensions/ERC20Wrapper.sol";
 import { IERC20Metadata } from "@oz/token/ERC20/extensions/IERC20Metadata.sol";
 
-/// @dev Ajna Token `ERC20` token interface.
+/**
+    * @title Ajna Token `ERC20` token interface.
+    * @dev Ajna Token `ERC20` token interface, including the following functions:
+    * - `burnFrom()`
+    * @dev Used by the `BurnWrappedAjna` contract to burn Ajna tokens on wrapping.
+    */
 interface IERC20Token {
     function burnFrom(address account, uint256 amount) external;
 }
 
+
+/**
+ *  @title  BurnWrappedAjna Contract
+ *  @notice Entrypoint of BurnWrappedAjna actions for Ajna token holders looking to migrate their assets to a sidechain:
+ *          - `TokenHolders`: Approve the BurnWrappedAjna contract to burn a specified amount of Ajna tokens, and mint them a corresponding amount of BurnWrappedAjna tokens.
+ *  @dev    This contract is intended for usage in cases where users are attempting to migrate their Ajna to a sidechain that lacks a permissionless bridge. 
+ *          Usage of this contract protects holders from the risk of a compromised sidechain bridge.
+ *  @dev    Contract inherits from OpenZeppelin ERC20Burnable and ERC20Wrapper extensions.
+ *  @dev    Only mainnet Ajna token can be wrapped. Tokens that have been wrapped cannot be unwrapped, as they are burned on wrapping.
+ */
 contract BurnWrappedAjna is ERC20, ERC20Burnable, ERC20Permit, ERC20Wrapper {
 
     /**

--- a/src/token/BurnWrapper.sol
+++ b/src/token/BurnWrapper.sol
@@ -18,6 +18,11 @@ import { IERC20Metadata } from "@oz/token/ERC20/extensions/IERC20Metadata.sol";
  * @dev Used by the `BurnWrappedAjna` contract to burn Ajna tokens on wrapping.
 */
 interface IERC20Token {
+    /**
+     * @notice Burns `amount` tokens from `account`, deducting from the caller's allowance and balance.
+     * @param account Account to burn tokens from.
+     * @param amount Amount of tokens to burn.
+     */
     function burnFrom(address account, uint256 amount) external;
 }
 
@@ -25,11 +30,12 @@ interface IERC20Token {
 /**
  *  @title  BurnWrappedAjna Contract
  *  @notice Entrypoint of BurnWrappedAjna actions for Ajna token holders looking to migrate their tokens to a sidechain:
- *          - `TokenHolders`: Approve the BurnWrappedAjna contract to burn a specified amount of Ajna tokens, and mint them a corresponding amount of BurnWrappedAjna tokens.
+ *          - `TokenHolders`: Approve the BurnWrappedAjna contract to burn a specified amount of Ajna tokens, and call `depositFor()` to mint them a corresponding amount of bwAJNA tokens.
  *  @dev    This contract is intended for usage in cases where users are attempting to migrate their Ajna to a sidechain that lacks a permissionless bridge.
  *          Usage of this contract protects holders from the risk of a compromised sidechain bridge.
  *  @dev    Contract inherits from OpenZeppelin ERC20Burnable and ERC20Wrapper extensions.
  *  @dev    Only mainnet Ajna token can be wrapped. Tokens that have been wrapped cannot be unwrapped, as they are burned on wrapping.
+ *  @dev    Holders must call `depositFor()` to wrap their tokens. Transferring Ajna tokens to the wrapper contract directly results in loss of tokens.
  */
 contract BurnWrappedAjna is ERC20, ERC20Burnable, ERC20Permit, ERC20Wrapper {
 

--- a/test/unit/BurnWrappedToken.t.sol
+++ b/test/unit/BurnWrappedToken.t.sol
@@ -42,7 +42,7 @@ contract BurnWrappedTokenTest is Test {
         _token.approve(address(_wrappedToken), amount_);
 
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(account_), address(_wrappedToken), amount_);
+        emit Transfer(address(account_), address(0), amount_);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(0), address(account_), amount_);
         (bool wrapSuccess) = _wrappedToken.depositFor(account_, amount_);
@@ -77,6 +77,7 @@ contract BurnWrappedTokenTest is Test {
 
         // check initial token supply
         assertEq(_token.totalSupply(),        1_000_000_000 * 10 ** _token.decimals());
+        assertEq(_token.totalSupply(),        _initialAjnaTokenSupply);
         assertEq(_wrappedToken.totalSupply(), 0);
 
         // transfer some tokens to the test address
@@ -99,8 +100,8 @@ contract BurnWrappedTokenTest is Test {
         assertEq(_token.balanceOf(address(_tokenDeployer)), _initialAjnaTokenSupply - tokensToWrap);
         assertEq(_wrappedToken.balanceOf(address(_tokenDeployer)), 0);
 
-        // check token supply after wrapping
-        assertEq(_token.totalSupply(),        1_000_000_000 * 10 ** _token.decimals());
+        // check token supply has decreased after wrapping by the wrapped amount
+        assertEq(_token.totalSupply(),        _initialAjnaTokenSupply - tokensToWrap);
         assertEq(_wrappedToken.totalSupply(), tokensToWrap);
     }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Instead of transferring Ajna to the BurnWrapper contract from which they can't be withdrawn, instead burn ajna tokens on wrap.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* https://github.com/sherlock-audit/2023-04-ajna-judging/issues/79
* This isn't really a bug or a vulnerability so much as an alternative design approach. It has some cons as well, as the burn wrapped tokens are potentially usable on other chains still making the total supply potentially less clear.
