### PR TITLE
Deploy BurnWrappedAjna

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,7 @@ deploy-grantfund:
 	eval AJNA_TOKEN=${ajna}
 	forge script script/GrantFund.s.sol:DeployGrantFund \
 		--rpc-url ${ETH_RPC_URL} --sender ${DEPLOY_ADDRESS} --keystore ${DEPLOY_KEY} --broadcast -vvv --verify
+deploy-burnwrapper:
+	eval AJNA_TOKEN=${ajna}
+	forge script script/BurnWrapper.s.sol:DeployBurnWrapper \
+		--rpc-url ${ETH_RPC_URL} --sender ${DEPLOY_ADDRESS} --keystore ${DEPLOY_KEY} --broadcast -vvv --verify

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ make deploy-ajnatoken mintto=<MINT_TO_ADDRESS>
 ```
 Record the address of the token upon deployment.  See [AJNA_TOKEN.md](src/token/AJNA_TOKEN.md#deployment) for validation.
 
+#### Burn Wrapper
+To deploy, ensure the correct AJNA token address is specified in code. Then, run:
+```
+make deploy-burnwrapper ajna=<AJNA_TOKEN_ADDRESS>
+```
+
 #### Grant Fund
 Deployment of the Grant Coordination Fund requires an argument to specify the address of the AJNA token. The deployment script also uses the token address to determine funding level.
 

--- a/script/BurnWrapper.s.sol
+++ b/script/BurnWrapper.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.7;
+
+import { Script }  from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+
+import { BurnWrappedAjna } from "../src/token/BurnWrapper.sol";
+import { IERC20 }    from "@oz/token/ERC20/IERC20.sol";
+
+contract DeployBurnWrapper is Script {
+    function run() public {
+        IERC20 ajna = IERC20(vm.envAddress("AJNA_TOKEN"));
+
+        vm.startBroadcast();
+        address wrapperAddress = address(new BurnWrappedAjna(ajna));
+        vm.stopBroadcast();
+
+        console.log("Created BurnWrapper at %s for AJNA token at %s", wrapperAddress, address(ajna));
+    }
+}


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
Implement forge script for deploying `BurnWrappedAjna` contract.  Could not do this with `forge create` because build process did not like different compiler versions.  Not happy about needing to manually edit source of `BurnWrapper.sol` such that it validates against the correct token address.

No changes to `src/`.

See alternate implementation PR#124 for an implementation which edits `src/` to remove the token address validation.