### PR TITLE
Deploy BurnWrappedAjna without address validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,7 @@ deploy-grantfund:
 	eval AJNA_TOKEN=${ajna}
 	forge script script/GrantFund.s.sol:DeployGrantFund \
 		--rpc-url ${ETH_RPC_URL} --sender ${DEPLOY_ADDRESS} --keystore ${DEPLOY_KEY} --broadcast -vvv --verify
+deploy-burnwrapper:
+	eval AJNA_TOKEN=${ajna}
+	forge script script/BurnWrapper.s.sol:DeployBurnWrapper \
+		--rpc-url ${ETH_RPC_URL} --sender ${DEPLOY_ADDRESS} --keystore ${DEPLOY_KEY} --broadcast -vvv --verify

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ make deploy-ajnatoken mintto=<MINT_TO_ADDRESS>
 ```
 Record the address of the token upon deployment.  See [AJNA_TOKEN.md](src/token/AJNA_TOKEN.md#deployment) for validation.
 
+#### Burn Wrapper
+To deploy, ensure the correct AJNA token address is specified in code. Then, run:
+```
+make deploy-burnwrapper ajna=<AJNA_TOKEN_ADDRESS>
+```
+
 #### Grant Fund
 Deployment of the Grant Coordination Fund requires an argument to specify the address of the AJNA token. The deployment script also uses the token address to determine funding level.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ make deploy-ajnatoken mintto=<MINT_TO_ADDRESS>
 Record the address of the token upon deployment.  See [AJNA_TOKEN.md](src/token/AJNA_TOKEN.md#deployment) for validation.
 
 #### Burn Wrapper
-To deploy, ensure the correct AJNA token address is specified in code. Then, run:
+To deploy, run:
 ```
 make deploy-burnwrapper ajna=<AJNA_TOKEN_ADDRESS>
 ```

--- a/script/BurnWrapper.s.sol
+++ b/script/BurnWrapper.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.7;
+
+import { Script }  from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+
+import { BurnWrappedAjna } from "../src/token/BurnWrapper.sol";
+import { IERC20 }    from "@oz/token/ERC20/IERC20.sol";
+
+contract DeployBurnWrapper is Script {
+    function run() public {
+        IERC20 ajna = IERC20(vm.envAddress("AJNA_TOKEN"));
+
+        vm.startBroadcast();
+        address wrapperAddress = address(new BurnWrappedAjna(ajna));
+        vm.stopBroadcast();
+
+        console.log("Created BurnWrapper at %s for AJNA token at %s", wrapperAddress, address(ajna));
+    }
+}

--- a/src/token/BurnWrapper.sol
+++ b/src/token/BurnWrapper.sol
@@ -14,29 +14,15 @@ import { IERC20Metadata } from "@oz/token/ERC20/extensions/IERC20Metadata.sol";
 contract BurnWrappedAjna is ERC20, ERC20Burnable, ERC20Permit, ERC20Wrapper {
 
     /**
-     * @notice Ethereum mainnet address of the Ajna Token.
-     */
-    address internal constant AJNA_TOKEN_ADDRESS = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
-
-    /**
      * @notice Tokens that have been wrapped cannot be unwrapped.
      */
     error UnwrapNotAllowed();
-
-    /**
-     * @notice Only mainnet Ajna token can be wrapped.
-     */
-    error InvalidWrappedToken();
 
     constructor(IERC20 wrappedToken)
         ERC20("Burn Wrapped AJNA", "bwAJNA")
         ERC20Permit("Burn Wrapped AJNA") // enables wrapped token to also use permit functionality
         ERC20Wrapper(wrappedToken)
-    {
-        if (address(wrappedToken) != AJNA_TOKEN_ADDRESS) {
-            revert InvalidWrappedToken();
-        }
-    }
+    {}
 
     /*****************/
     /*** OVERRIDES ***/

--- a/test/unit/BurnWrappedToken.t.sol
+++ b/test/unit/BurnWrappedToken.t.sol
@@ -104,13 +104,6 @@ contract BurnWrappedTokenTest is Test {
         assertEq(_wrappedToken.totalSupply(), tokensToWrap);
     }
 
-    function testOnlyWrapAjna() external {
-        ERC20 _invalidToken = new ERC20("Invalid Token", "INV");
-
-        vm.expectRevert(BurnWrappedAjna.InvalidWrappedToken.selector);
-        new BurnWrappedAjna(IERC20(address(_invalidToken)));
-    }
-
     function testCantUnwrap() external {
         uint256 tokensToWrap = 50 * 1e18;
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
Alternative implementation of PR#123 which eliminates the address validation, allowing it to be deployed to Goerli and local testchains without code changes.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
This change does not target a vulnerability.

# Contract size
## Pre Change
| Contract              | Size (kB) | Margin (kB) |
|-----------------------|-----------|-------------|
| BurnWrappedAjna       | 5.277     | 19.299      |
## Post Change
| Contract              | Size (kB) | Margin (kB) |
|-----------------------|-----------|-------------|
| BurnWrappedAjna       | 5.277     | 19.299      |


# Gas usage
There was a small reduction in deployment cost.
## Pre Change
| BurnWrappedAjna contract |                 |       |        |       |         |
|----------------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                                    | Deployment Size |       |        |       |         |
| 1400933                                            | 7662            |       |        |       |         |
| Function Name                                      | min             | avg   | median | max   | # calls |
| balanceOf                                          | 561             | 1227  | 561    | 2561  | 6       |
| decimals                                           | 222             | 222   | 222    | 222   | 1       |
| depositFor                                         | 59633           | 61233 | 61233  | 62833 | 2       |
| name                                               | 3246            | 3246  | 3246   | 3246  | 1       |
| symbol                                             | 3267            | 3267  | 3267   | 3267  | 1       |
| totalSupply                                        | 349             | 1349  | 1349   | 2349  | 2       |
| withdrawTo                                         | 440             | 440   | 440    | 440   | 1       |

## Post Change
| BurnWrappedAjna contract |                 |       |        |       |         |
|----------------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                                    | Deployment Size |       |        |       |         |
| 1400893                                            | 7605            |       |        |       |         |
| Function Name                                      | min             | avg   | median | max   | # calls |
| balanceOf                                          | 561             | 1227  | 561    | 2561  | 6       |
| decimals                                           | 222             | 222   | 222    | 222   | 1       |
| depositFor                                         | 59633           | 61233 | 61233  | 62833 | 2       |
| name                                               | 3246            | 3246  | 3246   | 3246  | 1       |
| symbol                                             | 3267            | 3267  | 3267   | 3267  | 1       |
| totalSupply                                        | 349             | 1349  | 1349   | 2349  | 2       |
| withdrawTo                                         | 440             | 440   | 440    | 440   | 1       |


