### PR TITLE
Simplify burn wrapper constructor

### DIFF
--- a/script/BurnWrapper.s.sol
+++ b/script/BurnWrapper.s.sol
@@ -12,7 +12,7 @@ contract DeployBurnWrapper is Script {
         IERC20 ajna = IERC20(vm.envAddress("AJNA_TOKEN"));
 
         vm.startBroadcast();
-        address wrapperAddress = address(new BurnWrappedAjna(ajna));
+        address wrapperAddress = address(new BurnWrappedAjna());
         vm.stopBroadcast();
 
         console.log("Created BurnWrapper at %s for AJNA token at %s", wrapperAddress, address(ajna));

--- a/src/token/BurnWrapper.sol
+++ b/src/token/BurnWrapper.sol
@@ -86,11 +86,4 @@ contract BurnWrappedAjna is ERC20, ERC20Burnable, ERC20Permit, ERC20Wrapper {
         revert UnwrapNotAllowed();
     }
 
-    /**
-     * @notice The underlying ajna token address.
-     */
-    function ajna() external pure returns (address) {
-        return AJNA_TOKEN_ADDRESS;
-    }
-
 }

--- a/src/token/BurnWrapper.sol
+++ b/src/token/BurnWrapper.sol
@@ -42,7 +42,7 @@ contract BurnWrappedAjna is ERC20, ERC20Burnable, ERC20Permit, ERC20Wrapper {
     /**
      * @notice Ethereum mainnet address of the Ajna Token.
      */
-    address public constant AJNA_TOKEN_ADDRESS = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
+    address internal constant AJNA_TOKEN_ADDRESS = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
 
     /**
      * @notice Tokens that have been wrapped cannot be unwrapped.
@@ -84,6 +84,10 @@ contract BurnWrappedAjna is ERC20, ERC20Burnable, ERC20Permit, ERC20Wrapper {
      */
     function withdrawTo(address, uint256) public pure override returns (bool) {
         revert UnwrapNotAllowed();
+    }
+
+    function ajna() external pure returns (address) {
+        return AJNA_TOKEN_ADDRESS;
     }
 
 }

--- a/src/token/BurnWrapper.sol
+++ b/src/token/BurnWrapper.sol
@@ -86,6 +86,9 @@ contract BurnWrappedAjna is ERC20, ERC20Burnable, ERC20Permit, ERC20Wrapper {
         revert UnwrapNotAllowed();
     }
 
+    /**
+     * @notice The underlying ajna token address.
+     */
     function ajna() external pure returns (address) {
         return AJNA_TOKEN_ADDRESS;
     }

--- a/src/token/BurnWrapper.sol
+++ b/src/token/BurnWrapper.sol
@@ -42,27 +42,18 @@ contract BurnWrappedAjna is ERC20, ERC20Burnable, ERC20Permit, ERC20Wrapper {
     /**
      * @notice Ethereum mainnet address of the Ajna Token.
      */
-    address internal constant AJNA_TOKEN_ADDRESS = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
+    address public constant AJNA_TOKEN_ADDRESS = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
 
     /**
      * @notice Tokens that have been wrapped cannot be unwrapped.
      */
     error UnwrapNotAllowed();
 
-    /**
-     * @notice Only mainnet Ajna token can be wrapped.
-     */
-    error InvalidWrappedToken();
-
-    constructor(IERC20 wrappedToken)
+    constructor()
         ERC20("Burn Wrapped AJNA", "bwAJNA")
         ERC20Permit("Burn Wrapped AJNA") // enables wrapped token to also use permit functionality
-        ERC20Wrapper(wrappedToken)
-    {
-        if (address(wrappedToken) != AJNA_TOKEN_ADDRESS) {
-            revert InvalidWrappedToken();
-        }
-    }
+        ERC20Wrapper(IERC20(AJNA_TOKEN_ADDRESS))
+    {}
 
     /*****************/
     /*** OVERRIDES ***/

--- a/test/unit/BurnWrappedToken.t.sol
+++ b/test/unit/BurnWrappedToken.t.sol
@@ -34,7 +34,7 @@ contract BurnWrappedTokenTest is Test {
 
         // reference mainnet deployment
         _token = AjnaToken(_ajnaAddress);
-        _wrappedToken = new BurnWrappedAjna(IERC20(address(_token)));
+        _wrappedToken = new BurnWrappedAjna();
     }
 
    function approveAndWrapTokens(address account_, uint256 amount_) internal {
@@ -106,10 +106,10 @@ contract BurnWrappedTokenTest is Test {
     }
 
     function testOnlyWrapAjna() external {
-        ERC20 _invalidToken = new ERC20("Invalid Token", "INV");
 
-        vm.expectRevert(BurnWrappedAjna.InvalidWrappedToken.selector);
-        new BurnWrappedAjna(IERC20(address(_invalidToken)));
+        BurnWrappedAjna _newBurnWrappedAjna = new BurnWrappedAjna();
+        assertEq(_newBurnWrappedAjna.AJNA_TOKEN_ADDRESS(), address(_ajnaAddress));
+
     }
 
     function testCantUnwrap() external {

--- a/test/unit/BurnWrappedToken.t.sol
+++ b/test/unit/BurnWrappedToken.t.sol
@@ -106,10 +106,8 @@ contract BurnWrappedTokenTest is Test {
     }
 
     function testOnlyWrapAjna() external {
-
         BurnWrappedAjna _newBurnWrappedAjna = new BurnWrappedAjna();
-        assertEq(_newBurnWrappedAjna.ajna(), address(_ajnaAddress));
-
+        assertEq(address(_newBurnWrappedAjna.underlying()), address(_ajnaAddress));
     }
 
     function testCantUnwrap() external {

--- a/test/unit/BurnWrappedToken.t.sol
+++ b/test/unit/BurnWrappedToken.t.sol
@@ -108,7 +108,7 @@ contract BurnWrappedTokenTest is Test {
     function testOnlyWrapAjna() external {
 
         BurnWrappedAjna _newBurnWrappedAjna = new BurnWrappedAjna();
-        assertEq(_newBurnWrappedAjna.AJNA_TOKEN_ADDRESS(), address(_ajnaAddress));
+        assertEq(_newBurnWrappedAjna.ajna(), address(_ajnaAddress));
 
     }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Simplifies the constructor of the BurnWrapper
  * The burnwrapper includes an unnecessary parameter to require the ajna token address. This is unnecessary since the ajna address is already a hardcoded constant in the contract. Using that constant allows us to remove the parameter requirement and also the associated error code.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Unnecessary code in constructor.
  * Constructor uses existing hardcoded ajna token address to compare with a parameter. The only path where this function succeeds is where the parameter matches the hardcoded address, so the parameter is extraneous. This solution:
    * Removes the address parameter from the constructor.
    * Removes the `InvalidWrappedToken` error message from address mismatch since it's no longer required.
    * Reduces overall deployment size.


# Contract size
## Pre Change
| src/token/BurnWrapper.sol:BurnWrappedAjna contract |                 |       |        |       |         |
|----------------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                                    | Deployment Size |       |        |       |         |
| 1250556                                            | 6904            |       |        |       |         |
## Post Change
| src/token/BurnWrapper.sol:BurnWrappedAjna contract |                 |       |        |       |         |
|----------------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                                    | Deployment Size |       |        |       |         |
| 1250346                                            | 6750            |       |        |       |         |

# Gas usage
## Pre Change
| src/token/BurnWrapper.sol:BurnWrappedAjna contract |                 |       |        |       |         |
|----------------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                                    | Deployment Size |       |        |       |         |
| 1250556                                            | 6904            |       |        |       |         |
| Function Name                                      | min             | avg   | median | max   | # calls |
| balanceOf                                          | 561             | 1227  | 561    | 2561  | 6       |
| decimals                                           | 222             | 222   | 222    | 222   | 1       |
| depositFor                                         | 67772           | 70172 | 70172  | 72572 | 2       |
| name                                               | 3226            | 3226  | 3226   | 3226  | 1       |
| symbol                                             | 3247            | 3247  | 3247   | 3247  | 1       |
| totalSupply                                        | 349             | 1349  | 1349   | 2349  | 2       |
| withdrawTo                                         | 440             | 440   | 440    | 440   | 1       |
## Post Change
| src/token/BurnWrapper.sol:BurnWrappedAjna contract |                 |       |        |       |         |
|----------------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                                    | Deployment Size |       |        |       |         |
| 1250346                                            | 6750            |       |        |       |         |
| Function Name                                      | min             | avg   | median | max   | # calls |
| balanceOf                                          | 561             | 1227  | 561    | 2561  | 6       |
| decimals                                           | 222             | 222   | 222    | 222   | 1       |
| depositFor                                         | 67772           | 70172 | 70172  | 72572 | 2       |
| name                                               | 3226            | 3226  | 3226   | 3226  | 1       |
| symbol                                             | 3247            | 3247  | 3247   | 3247  | 1       |
| totalSupply                                        | 349             | 1349  | 1349   | 2349  | 2       |
| underlying                                         | 272             | 272   | 272    | 272   | 1       |
| withdrawTo                                         | 440             | 440   | 440    | 440   | 1       |


