### PR TITLE
Cut internal var and deploy/run cost of fundTreasury

### DIFF
--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -93,8 +93,6 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
 
     /// @inheritdoc IGrantFundActions
     function fundTreasury(uint256 fundingAmount_) external override {
-        IERC20 token = IERC20(ajnaTokenAddress);
-
         // update treasury accounting
         uint256 newTreasuryAmount = treasury + fundingAmount_;
         treasury = newTreasuryAmount;
@@ -102,7 +100,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         emit FundTreasury(fundingAmount_, newTreasuryAmount);
 
         // transfer ajna tokens to the treasury
-        token.safeTransferFrom(msg.sender, address(this), fundingAmount_);
+        IERC20(ajnaTokenAddress).safeTransferFrom(msg.sender, address(this), fundingAmount_);
     }
 
     /**************************************************/
@@ -145,7 +143,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
     /**
      * @notice Updates Treasury with surplus funds from distribution.
      * @dev    Counters incremented in an unchecked block due to being bounded by array length of at most 10.
-     * @param distributionId_ distribution Id of updating distribution 
+     * @param distributionId_ distribution Id of updating distribution
      */
     function _updateTreasury(
         uint24 distributionId_
@@ -755,7 +753,7 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
 
         FundingVoteParams[] storage votesCast = voter_.votesCast;
 
-        // check that the voter hasn't already voted on a proposal by seeing if it's already in the votesCast array 
+        // check that the voter hasn't already voted on a proposal by seeing if it's already in the votesCast array
         int256 voteCastIndex = _findProposalIndexOfVotesCast(proposalId, votesCast);
 
         // voter had already cast a funding vote on this proposal


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Eliminate single-use local var

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Minor optimization to eliminate the declaration of a local var that is only used once

# Contract size
## Pre Change
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |
|---------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                             | Deployment Size |        |        |        |         |
| 4062280                                     | 20296           |        |        |        |         |
## Post Change
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |
|---------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                             | Deployment Size |        |        |        |         |
| 4057271                                     | 20271           |        |        |        |         |

# Gas usage
## Pre Change
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |
|---------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                             | Deployment Size |        |        |        |         |
| 4062280                                     | 20296           |        |        |        |         |
| Function Name                               | min             | avg    | median | max    | # calls |
| fundTreasury                                | 7809            | 41952  | 44449  | 65320  | 30      |
## Post Change
| src/grants/GrantFund.sol:GrantFund contract |                 |        |        |        |         |
|---------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                             | Deployment Size |        |        |        |         |
| 4057271                                     | 20271           |        |        |        |         |
| Function Name                               | min             | avg    | median | max    | # calls |
| fundTreasury                                | 7793            | 41936  | 44433  | 65304  | 30      |

