### PR TITLE
return 0 for getDelegateRewards if voter didn't vote in the screening stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build  :; forge clean && forge build --optimize --optimizer-runs 1000000
 # Tests
 tests                                :; forge clean && forge test --mt test --optimize --optimizer-runs 1000000 -v # --ffi # enable if you need the `ffi` cheat code on HEVM
 test-with-gas-report                 :; forge clean && forge build && forge test --mt test --optimize --optimizer-runs 1000000 -v --gas-report # --ffi # enable if you need the `ffi` cheat code on HEVM
+test-unit							 :; forge clean && forge test --no-match-test invariant --optimize --optimizer-runs 1000000 -v # --ffi # enable if you need the `ffi` cheat code on HEVM
 test-invariant                       :; ./test/invariants/test-invariant.sh ${SCENARIO} ${NUM_ACTORS} ${NUM_PROPOSALS} ${PER_ADDRESS_TOKEN_REQ_CAP}
 test-invariant-all                   :; forge clean && forge t --mt invariant
 test-invariant-multiple-distribution :; forge clean && ./test/invariants/test-invariant.sh MultipleDistribution 2 25 200

--- a/src/grants/GrantFund.sol
+++ b/src/grants/GrantFund.sol
@@ -1099,6 +1099,8 @@ contract GrantFund is IGrantFund, Storage, ReentrancyGuard {
         DistributionPeriod storage currentDistribution = _distributions[distributionId_];
         VoterInfo          storage voter               = _voterInfo[distributionId_][voter_];
 
+        if (voter.screeningVotesCast == 0) return 0;
+
         rewards_ = _getDelegateReward(currentDistribution, voter);
     }
 

--- a/test/unit/StandardFunding.t.sol
+++ b/test/unit/StandardFunding.t.sol
@@ -1273,6 +1273,10 @@ contract StandardFundingGrantFundTest is GrantFundTestHelper {
         /******************************/
 
         // Claim delegate reward for all delegatees
+        // delegates who didn't vote in the screening stage have zero rewards
+        delegateRewards = _grantFund.getDelegateReward(distributionId, _tokenHolder11);
+        assertEq(delegateRewards, 0);
+
         // delegates who didn't vote with their full power receive fewer rewards
         delegateRewards = _grantFund.getDelegateReward(distributionId, _tokenHolder1);
         assertEq(delegateRewards, 327_029.344384908148174595 * 1e18);


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* return 0 for `getDelegateRewards` if voter didn't vote in the screening stage

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* `getDelegateReward` returned incorrect values if called when a voter didn't vote in the screening stage.
* https://github.com/Fixed-Point-Solutions/ajna-PositionManager-RewardsManager/issues/24
